### PR TITLE
[Feature/#51] 채팅방 입장 API 구현

### DIFF
--- a/server/src/api/Room/enterRoom/enterRoom.graphql
+++ b/server/src/api/Room/enterRoom/enterRoom.graphql
@@ -1,0 +1,3 @@
+type Mutation {
+  enterRoom(nickname: String!, avatar: String!, lang: String!, code: String!): String!
+}

--- a/server/src/api/Room/enterRoom/enterRoom.graphql
+++ b/server/src/api/Room/enterRoom/enterRoom.graphql
@@ -1,3 +1,3 @@
 type Mutation {
-  enterRoom(nickname: String!, avatar: String!, lang: String!, code: String!): String!
+  enterRoom(nickname: String!, avatar: String!, lang: String!, code: String!): Int!
 }

--- a/server/src/api/Room/enterRoom/enterRoom.ts
+++ b/server/src/api/Room/enterRoom/enterRoom.ts
@@ -1,0 +1,35 @@
+import { PrismaClient } from '@prisma/client';
+import errorMessage from '@utils/errorMessage';
+
+const prisma = new PrismaClient();
+
+interface User {
+  nickname: string;
+  avatar: string;
+  lang: string;
+  code: string;
+}
+
+export default {
+  Mutation: {
+    enterRoom: async (_: any, { nickname, avatar, lang, code }: User): Promise<boolean> => {
+      try {
+        await prisma.user.create({
+          data: {
+            nickname,
+            lang,
+            avatar,
+            rooms: {
+              connect: { code },
+            },
+          },
+          include: { rooms: true },
+        });
+
+        return true;
+      } catch (error) {
+        throw new Error(errorMessage.already);
+      }
+    },
+  },
+};

--- a/server/src/api/Room/enterRoom/enterRoom.ts
+++ b/server/src/api/Room/enterRoom/enterRoom.ts
@@ -3,7 +3,7 @@ import errorMessage from '@utils/errorMessage';
 
 const prisma = new PrismaClient();
 
-interface User {
+interface EnterInfo {
   nickname: string;
   avatar: string;
   lang: string;
@@ -12,24 +12,20 @@ interface User {
 
 export default {
   Mutation: {
-    enterRoom: async (_: any, { nickname, avatar, lang, code }: User): Promise<boolean> => {
-      try {
-        await prisma.user.create({
-          data: {
-            nickname,
-            lang,
-            avatar,
-            rooms: {
-              connect: { code },
-            },
+    enterRoom: async (_: any, { nickname, avatar, lang, code }: EnterInfo): Promise<number> => {
+      const result = await prisma.user.create({
+        data: {
+          nickname,
+          lang,
+          avatar,
+          rooms: {
+            connect: { code },
           },
-          include: { rooms: true },
-        });
+        },
+        include: { rooms: true },
+      });
 
-        return true;
-      } catch (error) {
-        throw new Error(errorMessage.already);
-      }
+      return result.rooms[0].id;
     },
   },
 };


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- user 생성 api 구현
- 원래 존재하는 채팅방이랑 user 연결
Issue #51

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 설정한 data를 기반으로 user를 생성합니다.
- [x] 입력한 채팅방 code에 해당하는 채팅방에 user를 입장시킵니다.
- [x] 두명 이상 user를 입장시키고 채팅방에 user가 2명이상 입장했는 지 확인 부탁드립니다.

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

- [m:n 관계 테이블 update](https://www.prisma.io/docs/concepts/components/prisma-client/relation-queries#one-to-many-relations)

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
