### PR TITLE
[Feature/#64] 채팅방 생성 시 해당 채팅방의 id를 반환하도록 함

### DIFF
--- a/server/src/api/Room/createRoom/createRoom.graphql
+++ b/server/src/api/Room/createRoom/createRoom.graphql
@@ -1,3 +1,8 @@
+type RoomResponse {
+  id: Int!
+  code: String!
+}
+
 type Mutation {
-  createRoom(nickname: String!, avatar: String!, lang: String!): String!
+  createRoom(nickname: String!, avatar: String!, lang: String!): RoomResponse!
 }

--- a/server/src/api/Room/createRoom/createRoom.ts
+++ b/server/src/api/Room/createRoom/createRoom.ts
@@ -11,7 +11,7 @@ interface User {
 
 export default {
   Mutation: {
-    createRoom: async (_: any, args: User): Promise<string> => {
+    createRoom: async (_: any, args: User): Promise<{ id: number; code: string }> => {
       const { nickname, avatar, lang } = args;
       const user = await prisma.user.create({
         data: {
@@ -21,7 +21,7 @@ export default {
         },
       });
       const randomCode = getRandomNumber(6);
-      await prisma.room.create({
+      const newRoom = await prisma.room.create({
         data: {
           users: {
             connect: {
@@ -32,7 +32,7 @@ export default {
           code: randomCode,
         },
       });
-      return randomCode;
+      return { id: newRoom.id, code: randomCode };
     },
   },
 };


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 채팅방 생성 시 해당 채팅방 내 메세지 조회를 위해 채팅방 id도
반환하도록 함

Issue #64

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 채팅방 생성 시 room code와 함께 room id가 넘어오는지 확인 부탁드립니다.

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
