### PR TITLE
[Bug/#81] 관계 테이블 데이터가 삭제되지 않는 버그

### DIFF
--- a/server/src/api/User/deleteUser/deleteUser.graphql
+++ b/server/src/api/User/deleteUser/deleteUser.graphql
@@ -1,3 +1,3 @@
 type Mutation {
-  deleteUser(id: Int!): Boolean!
+  deleteUser(userId: Int!, roomId: Int!): Boolean!
 }

--- a/server/src/api/User/deleteUser/deleteUser.ts
+++ b/server/src/api/User/deleteUser/deleteUser.ts
@@ -1,39 +1,19 @@
 import { PrismaClient } from '@prisma/client';
-import errorMessage from '@utils/errorMessage';
 
 const prisma = new PrismaClient();
 
 export default {
   Mutation: {
-    deleteUser: async (_: any, { id: userId }: { id: number }): Promise<boolean> => {
-      try {
-        /**
-         * 1. 유저 삭제 (삭제할때 해당 유저가 속한 방번호 조회)
-         * 2. 유저가 속했던 방에 남은 유저가 몇명 있는지 조회해서
-         * 3. 해당 방에 유저가 0명 있으면 방도 같이 지우기
-         */
-        const deleteUserResult = await prisma.user.delete({
-          where: { id: userId },
-          include: { rooms: true },
-        });
-
-        const roomId = deleteUserResult.rooms[0].id;
-
-        const afterRoom = await prisma.room.findOne({
-          where: { id: roomId },
-          include: { users: true },
-        });
-
-        if (afterRoom?.users.length === 0) {
-          await prisma.room.delete({
-            where: { id: roomId },
-          });
-        }
-
-        return true;
-      } catch (error) {
-        throw new Error(errorMessage.delete);
+    deleteUser: async (
+      _: any,
+      { userId, roomId }: { userId: number; roomId: number },
+    ): Promise<boolean> => {
+      await prisma.$queryRaw`DELETE FROM User WHERE id = ${userId}`;
+      const restUser = await prisma.$queryRaw`SELECT COUNT(*) FROM _RoomToUser WHERE A = ${roomId} `;
+      if (!restUser[0]['COUNT(*)']) {
+        await prisma.$queryRaw`DELETE FROM Room WHERE id = ${roomId}`;
       }
+      return true;
     },
   },
 };


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

Issue #81
- prisma에서 관계 테이블에 대해 데이터 삭제를 지원하지 않는 문제.
- prisma의 queryRaw를 이용해서 데이터를 삭제 부탁드립니다.

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] User를 User가 작성한 모든 message가 삭제되었는 지 확인 부탁드립니다.
- [x] User를 삭제 시 유저가 입장 한 채팅방 목록에서 User가 사라졌는 지 확인 부탁드립니다.
- [x] User 삭제 시 채팅방 인원이 모두 사라졌을 경우 채팅방도 삭제 되었는 지 확인 부탁드립니다.

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

[Prisma queryRaw](https://www.prisma.io/docs/concepts/components/prisma-client/raw-database-access)

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
