### PR TITLE
[Featuer/#125]  서버 API 변경에 의한 메시지 추가 로직 변경

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
+++ b/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		995BE9CD25760B2F00C15AC7 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE9CC25760B2F00C15AC7 /* API.swift */; };
 		995BE9D1257621B700C15AC7 /* UserDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE9D0257621B700C15AC7 /* UserDataProvider.swift */; };
 		995BE9D525762AC500C15AC7 /* UserDataProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE9D425762AC500C15AC7 /* UserDataProviding.swift */; };
+		995BE9F72576350A00C15AC7 /* TranslateResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE9F62576350A00C15AC7 /* TranslateResult.swift */; };
 		996A1433256D040B00F21215 /* ImageFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996A1432256D040B00F21215 /* ImageFactory.swift */; };
 		996A1446256D187900F21215 /* ImageFactoryProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996A1445256D187900F21215 /* ImageFactoryProviding.swift */; };
 		996A145D256D324600F21215 /* LanguageSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996A145C256D324600F21215 /* LanguageSelectionView.swift */; };
@@ -112,6 +113,7 @@
 		995BE9CC25760B2F00C15AC7 /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
 		995BE9D0257621B700C15AC7 /* UserDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataProvider.swift; sourceTree = "<group>"; };
 		995BE9D425762AC500C15AC7 /* UserDataProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataProviding.swift; sourceTree = "<group>"; };
+		995BE9F62576350A00C15AC7 /* TranslateResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateResult.swift; sourceTree = "<group>"; };
 		996A1432256D040B00F21215 /* ImageFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFactory.swift; sourceTree = "<group>"; };
 		996A1445256D187900F21215 /* ImageFactoryProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageFactoryProviding.swift; sourceTree = "<group>"; };
 		996A145C256D324600F21215 /* LanguageSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSelectionView.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 			isa = PBXGroup;
 			children = (
 				BBEA1A5B256F4678009B8B5F /* Message.swift */,
+				995BE9F62576350A00C15AC7 /* TranslateResult.swift */,
 				BBEA1A5F256F46FE009B8B5F /* User.swift */,
 			);
 			path = Entity;
@@ -695,6 +698,7 @@
 				BB1200A125701B4000CC8020 /* RxSwift+.swift in Sources */,
 				990DE957257367B800340A72 /* JoinChatResponse.swift in Sources */,
 				990DE94D2573479600340A72 /* AlertFactory.swift in Sources */,
+				995BE9F72576350A00C15AC7 /* TranslateResult.swift in Sources */,
 				BB6F7EC4256D698B00D66F8E /* ChatViewReactor.swift in Sources */,
 				99A2768425668EFA008BD24C /* HomeViewController.swift in Sources */,
 				995BE9CD25760B2F00C15AC7 /* API.swift in Sources */,

--- a/iOS/PapagoTalk/PapagoTalk/Entity/TranslateResult.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/TranslateResult.swift
@@ -1,0 +1,13 @@
+//
+//  TranslateResult.swift
+//  PapagoTalk
+//
+//  Created by Byoung-Hwi Yoon on 2020/12/01.
+//
+
+import Foundation
+
+struct TranslateResult: Codable {
+    var originText: String
+    var translatedText: String
+}


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 메시지 텍스트에 원문과 번역된 메시지를 json string으로 전달
- 이를 decoding하여 원문과 번역된 메시지를 각각 추가
- 자신이 보낸 메시지의 경우 원문만 추가
   - 메시지 작성시 번역 결과를 보여주는것으로 대체


## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 내 메시지는 원문만 출력하는가
- [x] 상대방의 메시지는 원문과 번역본을 각각 출력하는가

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타
<img width="356" alt="스크린샷 2020-12-01 오후 6 29 13" src="https://user-images.githubusercontent.com/48614208/100722043-7f497980-3403-11eb-844c-21d7de0bc435.png">

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
