### PR TITLE
[Feature/#167]  번역메시지 별도 메시지셀로 구분

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
+++ b/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		993AF6792574DF2F00416692 /* CreateRoomResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993AF6782574DF2F00416692 /* CreateRoomResponse.swift */; };
 		993AF67D2574E3E200416692 /* HomeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993AF67C2574E3E200416692 /* HomeError.swift */; };
 		993AF698257517AE00416692 /* KeyboardProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993AF697257517AE00416692 /* KeyboardProviding.swift */; };
+		99482DA72578AF8900802B45 /* TranslatedMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482DA62578AF8900802B45 /* TranslatedMessageCell.swift */; };
 		995BE99F2575DF9400C15AC7 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE99E2575DF9400C15AC7 /* Coordinator.swift */; };
 		995BE9AB2575E8E500C15AC7 /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE9AA2575E8E500C15AC7 /* MainCoordinator.swift */; };
 		995BE9C32576093400C15AC7 /* schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 995BE9C22576093400C15AC7 /* schema.json */; };
@@ -118,6 +119,7 @@
 		993AF6782574DF2F00416692 /* CreateRoomResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateRoomResponse.swift; sourceTree = "<group>"; };
 		993AF67C2574E3E200416692 /* HomeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeError.swift; sourceTree = "<group>"; };
 		993AF697257517AE00416692 /* KeyboardProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardProviding.swift; sourceTree = "<group>"; };
+		99482DA62578AF8900802B45 /* TranslatedMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslatedMessageCell.swift; sourceTree = "<group>"; };
 		995BE99E2575DF9400C15AC7 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		995BE9AA2575E8E500C15AC7 /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 		995BE9C22576093400C15AC7 /* schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = schema.json; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 				BB9A86A3257487C800FE14D6 /* MessageCell.swift */,
 				996C4E91257005C20015F9F4 /* SentMessageCell.swift */,
 				996C4E97257006670015F9F4 /* ReceivedMessageCell.swift */,
+				99482DA62578AF8900802B45 /* TranslatedMessageCell.swift */,
 				996479362576854900CFF202 /* MessageText.swift */,
 				9964793A2576901200CFF202 /* InputBarTextView.swift */,
 				9964797D2577670A00CFF202 /* MicrophoneButton.swift */,
@@ -709,6 +712,7 @@
 				BB93C2942575345200C68491 /* Calendar+.swift in Sources */,
 				996479922577BF4900CFF202 /* SpeechViewDelegate.swift in Sources */,
 				990DE923257265BB00340A72 /* ChatCodeInputViewController.swift in Sources */,
+				99482DA72578AF8900802B45 /* TranslatedMessageCell.swift in Sources */,
 				996479962577BFAA00CFF202 /* ChatViewController + SpeechView.swift in Sources */,
 				995BE9D1257621B700C15AC7 /* UserDataProvider.swift in Sources */,
 				996A1433256D040B00F21215 /* ImageFactory.swift in Sources */,

--- a/iOS/PapagoTalk/PapagoTalk/Base.lproj/Main.storyboard
+++ b/iOS/PapagoTalk/PapagoTalk/Base.lproj/Main.storyboard
@@ -1004,8 +1004,8 @@
                                                     <rect key="frame" x="12" y="40" width="42" height="42"/>
                                                     <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                     <constraints>
+                                                        <constraint firstAttribute="width" constant="42" id="XBa-mG-INr"/>
                                                         <constraint firstAttribute="height" priority="999" constant="42" id="blP-3z-br4"/>
-                                                        <constraint firstAttribute="width" secondItem="ymh-Tr-sLT" secondAttribute="height" multiplier="1:1" id="mIq-4X-y4O"/>
                                                     </constraints>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
@@ -1051,8 +1051,8 @@
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </textView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 6:25" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d8P-YL-lNQ">
-                                                    <rect key="frame" x="162" y="87.666666666666671" width="51" height="14.333333333333329"/>
+                                                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 8:13" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d8P-YL-lNQ">
+                                                    <rect key="frame" x="162" y="87.666666666666671" width="48.666666666666657" height="14.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1084,6 +1084,68 @@
                                             <outlet property="nickNameLabel" destination="zyP-S3-xoJ" id="rwX-Ua-6Zr"/>
                                             <outlet property="profileImageView" destination="ymh-Tr-sLT" id="ekO-5O-I7y"/>
                                             <outlet property="timeLabel" destination="d8P-YL-lNQ" id="8cZ-We-Yrh"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="TranslatedMessageCell" id="gHZ-8k-9Wd" customClass="TranslatedMessageCell" customModule="PapagoTalk" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="200" width="414" height="49.333333333333343"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="wfa-x1-yLv">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="49.333333333333343"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" usesAttributedText="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X2k-0w-q3r" customClass="MessageText" customModule="PapagoTalk" customModuleProvider="target">
+                                                    <rect key="frame" x="64" y="8" width="88" height="33.333333333333336"/>
+                                                    <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" id="gzc-rD-VbF"/>
+                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="240" id="lYJ-sK-KS7"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" id="ty1-kS-FqF"/>
+                                                    </constraints>
+                                                    <attributedString key="attributedText">
+                                                        <fragment content="안녕하세요">
+                                                            <attributes>
+                                                                <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                <font key="NSFont" size="14" name="AppleSDGothicNeo-Regular"/>
+                                                                <font key="NSOriginalFont" size="14" name="Helvetica"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                        <fragment content=" Hi">
+                                                            <attributes>
+                                                                <color key="NSColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                <font key="NSFont" size="14" name="Helvetica"/>
+                                                                <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                                            </attributes>
+                                                        </fragment>
+                                                    </attributedString>
+                                                    <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                            <real key="value" value="12"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </textView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 8:13" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mF7-5M-TlD">
+                                                    <rect key="frame" x="164" y="26.999999999999996" width="48.666666666666657" height="14.333333333333332"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" id="LLW-gC-he8"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="systemGrayColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="X2k-0w-q3r" secondAttribute="bottom" constant="8" id="7mA-P4-4aU"/>
+                                                <constraint firstItem="X2k-0w-q3r" firstAttribute="leading" secondItem="wfa-x1-yLv" secondAttribute="leading" constant="64" id="995-Ve-NCe"/>
+                                                <constraint firstItem="mF7-5M-TlD" firstAttribute="leading" secondItem="X2k-0w-q3r" secondAttribute="trailing" constant="12" id="G4s-C9-Y7v"/>
+                                                <constraint firstItem="mF7-5M-TlD" firstAttribute="bottom" secondItem="X2k-0w-q3r" secondAttribute="bottom" id="T8r-mU-B1o"/>
+                                                <constraint firstItem="X2k-0w-q3r" firstAttribute="top" secondItem="wfa-x1-yLv" secondAttribute="top" constant="8" id="cgQ-cC-U7R"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="messageTextView" destination="X2k-0w-q3r" id="ve8-00-5j8"/>
+                                            <outlet property="timeLabel" destination="mF7-5M-TlD" id="E3b-6A-DsP"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>

--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewReactor.swift
@@ -102,7 +102,8 @@ final class ChatViewReactor: Reactor {
                                             of: translateResult.translatedText,
                                             by: sender,
                                             language: userData.language.code,
-                                            timeStamp: time)
+                                            timeStamp: time,
+                                            isTranslated: true)
             messages.append(translatedMessage)
         }
         return messages

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/ReceivedMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/ReceivedMessageCell.swift
@@ -25,7 +25,6 @@ extension ReceivedMessageCell: MessageCell {
         configureImage(with: message.sender.image)
         configureNickName(with: message.sender.nickName)
         configureMessage(of: messageTextView, with: message.text)
-        configureTime(of: timeLabel, with: message.timeStamp)
     }
     
     private func configureImage(with imageURL: String) {
@@ -39,3 +38,5 @@ extension ReceivedMessageCell: MessageCell {
         nickNameLabel.text = nickName
     }
 }
+
+

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/TranslatedMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/TranslatedMessageCell.swift
@@ -1,0 +1,20 @@
+//
+//  TranslatedMessageCell.swift
+//  PapagoTalk
+//
+//  Created by Byoung-Hwi Yoon on 2020/12/03.
+//
+
+import UIKit
+
+final class TranslatedMessageCell: UICollectionViewCell {
+    @IBOutlet weak var messageTextView: MessageText!
+    @IBOutlet weak var timeLabel: UILabel!
+}
+
+extension TranslatedMessageCell: MessageCell {
+    func configureMessageCell(message: Message) {
+        configureMessage(of: messageTextView, with: message.text)
+        configureTime(of: timeLabel, with: message.timeStamp)
+    }
+}

--- a/iOS/PapagoTalk/PapagoTalk/Common/Enum/MessageType.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Common/Enum/MessageType.swift
@@ -10,6 +10,7 @@ import Foundation
 enum MessageType: String, Codable {
     case sent
     case received
+    case translated
     
     var identifier: String {
         switch self {
@@ -17,6 +18,8 @@ enum MessageType: String, Codable {
             return SentMessageCell.identifier
         case .received:
             return ReceivedMessageCell.identifier
+        case .translated:
+            return TranslatedMessageCell.identifier
         }
     }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
@@ -15,6 +15,7 @@ struct Message: Codable {
     let timeStamp: Date
     var isFirstOfDay: Bool
     var type: MessageType
+    var isTranslated: Bool
     
     init(of text: String, by sender: User) {
         self.id = nil
@@ -24,9 +25,10 @@ struct Message: Codable {
         self.timeStamp = Date()
         self.isFirstOfDay = true
         self.type = .sent
+        isTranslated = false
     }
     
-    init(id: Int, of text: String, by sender: User, language: String, timeStamp: String) {
+    init(id: Int, of text: String, by sender: User, language: String, timeStamp: String, isTranslated: Bool = false) {
         self.id = id
         self.text = text
         self.sender = sender
@@ -34,6 +36,7 @@ struct Message: Codable {
         self.timeStamp = timeStamp.toDate()
         self.isFirstOfDay = true
         self.type = .received
+        self.isTranslated = isTranslated
     }
     
     mutating func setIsFirst(with isFirst: Bool) {
@@ -41,6 +44,10 @@ struct Message: Codable {
     }
     
     mutating func setType(by userID: Int) {
+        if isTranslated {
+            type = .translated
+            return
+        }
         type = (sender.id == userID) ? .sent : .received
     }
 }


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 번역된 메시지는 한번에 보여주기 위한 별도 셀로 구분
- 메시지에 isTranslated 플래그 추가
- 메시지 타입에 transratedMessage 추가
- 플래그 및 타입 추가에 의한 변경

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 번역된 메시지에서 닉네임과 이미지가 출력되지 않는가
- [x] UI가 이전보다 개선되었는가

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
