### PR TITLE
[Feature/#190] iOS 음성인식화면 메시지 전송 기능 구현

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
+++ b/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		993AF698257517AE00416692 /* KeyboardProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 993AF697257517AE00416692 /* KeyboardProviding.swift */; };
 		99482D9B2578874000802B45 /* PapagoAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482D9A2578874000802B45 /* PapagoAPIManager.swift */; };
 		99482DA72578AF8900802B45 /* TranslatedMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482DA62578AF8900802B45 /* TranslatedMessageCell.swift */; };
+		99482DFD2579425400802B45 /* RevisionedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482DFC2579425400802B45 /* RevisionedData.swift */; };
 		995BE99F2575DF9400C15AC7 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE99E2575DF9400C15AC7 /* Coordinator.swift */; };
 		995BE9AB2575E8E500C15AC7 /* MainCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE9AA2575E8E500C15AC7 /* MainCoordinator.swift */; };
 		995BE9C32576093400C15AC7 /* schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 995BE9C22576093400C15AC7 /* schema.json */; };
@@ -126,6 +127,7 @@
 		993AF697257517AE00416692 /* KeyboardProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardProviding.swift; sourceTree = "<group>"; };
 		99482D9A2578874000802B45 /* PapagoAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PapagoAPIManager.swift; sourceTree = "<group>"; };
 		99482DA62578AF8900802B45 /* TranslatedMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslatedMessageCell.swift; sourceTree = "<group>"; };
+		99482DFC2579425400802B45 /* RevisionedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevisionedData.swift; sourceTree = "<group>"; };
 		995BE99E2575DF9400C15AC7 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		995BE9AA2575E8E500C15AC7 /* MainCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinator.swift; sourceTree = "<group>"; };
 		995BE9C22576093400C15AC7 /* schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = schema.json; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 			isa = PBXGroup;
 			children = (
 				993AF697257517AE00416692 /* KeyboardProviding.swift */,
+				99482DFC2579425400802B45 /* RevisionedData.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -733,6 +736,7 @@
 				990DE923257265BB00340A72 /* ChatCodeInputViewController.swift in Sources */,
 				99482DA72578AF8900802B45 /* TranslatedMessageCell.swift in Sources */,
 				996479962577BFAA00CFF202 /* ChatViewController + SpeechView.swift in Sources */,
+				99482DFD2579425400802B45 /* RevisionedData.swift in Sources */,
 				995BE9D1257621B700C15AC7 /* UserDataProvider.swift in Sources */,
 				996A1433256D040B00F21215 /* ImageFactory.swift in Sources */,
 				996C4E51256E7BF90015F9F4 /* ApolloNetworkService.swift in Sources */,

--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController + SpeechView.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController + SpeechView.swift
@@ -14,11 +14,12 @@ extension ChatViewController: SpeechViewDelegate {
         view.addSubview(microphoneButton)
     }
     
-    func showSpeechView() {
+    func showSpeechView(roomID: Int) {
         guard let speechViewController = storyboard?.instantiateViewController(identifier: SpeechViewController.identifier) as? SpeechViewController else {
             return
         }
         speechViewController.delegate = self
+        speechViewController.roomID = roomID
         addChild(speechViewController)
         speechViewController.view.frame = CGRect(x: (view.frame.width - Constant.speechViewWidth)/2.0,
                                                  y: (view.frame.height - Constant.speechViewHeight)/2.0,

--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewReactor.swift
@@ -14,12 +14,14 @@ final class ChatViewReactor: Reactor {
         case subscribeNewMessages
         case sendMessage(String)
         case chatDrawerButtonTapped
+        case microphoneButtonTapped
     }
     
     enum Mutation {
         case appendNewMessage([Message])
         case setSendResult(Bool)
         case toggleDrawerState
+        case showSpeechView
     }
     
     struct State {
@@ -27,6 +29,7 @@ final class ChatViewReactor: Reactor {
         var sendResult: Bool = true
         var roomCode: String
         var toggleDrawer: ToggleDrawer
+        var showSpeechView: RevisionedData<(Bool,Int)>
         
         struct ToggleDrawer: Equatable {
             var drawerState: Bool
@@ -50,7 +53,8 @@ final class ChatViewReactor: Reactor {
         self.roomID = roomID
         initialState = State(messageBox: MessageBox(userID: userData.id),
                              roomCode: code,
-                             toggleDrawer: State.ToggleDrawer(drawerState: false, roomID: roomID))
+                             toggleDrawer: State.ToggleDrawer(drawerState: false, roomID: roomID),
+                             showSpeechView: RevisionedData(data: (false,roomID)))
     }
     
     func mutate(action: Action) -> Observable<Mutation> {
@@ -60,7 +64,9 @@ final class ChatViewReactor: Reactor {
         case .sendMessage(let message):
             return requestSendMessage(message: message)
         case .chatDrawerButtonTapped:
-            return Observable.just(Mutation.toggleDrawerState)
+            return .just(Mutation.toggleDrawerState)
+        case .microphoneButtonTapped:
+            return .just(Mutation.showSpeechView)
         }
     }
     
@@ -74,6 +80,8 @@ final class ChatViewReactor: Reactor {
             state.sendResult = isSuccess
         case .toggleDrawerState:
             state.toggleDrawer.drawerState.toggle()
+        case .showSpeechView:
+            state.showSpeechView = state.showSpeechView.update((true,roomID))
         }
         return state
     }

--- a/iOS/PapagoTalk/PapagoTalk/Chat/SpeechViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/SpeechViewController.swift
@@ -21,10 +21,12 @@ final class SpeechViewController: UIViewController, StoryboardView {
     
     weak var delegate: SpeechViewDelegate?
     var disposeBag = DisposeBag()
+    var roomID = 0 // Coordinator 적용시 제거
     
     override func viewDidLoad() {
         super.viewDidLoad()
         reactor = SpeechViewReactor()
+        reactor?.roomID = roomID // Coordinator 적용시 제거
         bind()
     }
     
@@ -42,9 +44,30 @@ final class SpeechViewController: UIViewController, StoryboardView {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        originSendButton.rx.tap
+            .withLatestFrom(originTextView.rx.text)
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .map { _ in Reactor.Action.originSendButtonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        translatedSendButton.rx.tap
+            .withLatestFrom(translatedTextView.rx.text)
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .map { _ in Reactor.Action.translatedSendButtonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         reactor.state.map { $0.speechRecognizedText }
             .distinctUntilChanged()
             .bind(to: originTextView.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state.map { $0.originText }
+            .distinctUntilChanged()
+            .bind(to: originTextView.rx.text )
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.translatedText }

--- a/iOS/PapagoTalk/PapagoTalk/Chat/SpeechViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/SpeechViewReactor.swift
@@ -15,6 +15,8 @@ final class SpeechViewReactor: Reactor {
         case speechTextChanged(String)
         case originTextChanged(String)
         case speechRecognitionAvailabiltyChanged(Bool)
+        case originSendButtonTapped
+        case translatedSendButtonTapped
     }
     
     enum Mutation {
@@ -22,6 +24,7 @@ final class SpeechViewReactor: Reactor {
         case setOriginText(String)
         case setTranslatedText(String)
         case setIsMicrophoneButtonEnable(Bool)
+        case clearTextView
     }
     
     struct State {
@@ -34,11 +37,13 @@ final class SpeechViewReactor: Reactor {
     private let speechManager = SpeechManager()
     private let translationManager = PapagoAPIManager()
     private let userData = UserDataProvider()
+    private let networkService = ApolloNetworkService()
+    var roomID: Int = 0
     let initialState: State
     var disposeBag = DisposeBag()
     
     init() {
-        initialState = State(speechRecognizedText: "", originText: "", translatedText: "...", isMicrophoneButtonEnable: true)
+        initialState = State(speechRecognizedText: "", originText: "", translatedText: "", isMicrophoneButtonEnable: true)
         bind()
     }
     
@@ -51,11 +56,21 @@ final class SpeechViewReactor: Reactor {
             return .just(Mutation.setSpeechRecognition(output))
         case .originTextChanged(let input):
             return .concat([
-                translate(text: input),
-                .just(Mutation.setOriginText(input))
+                .just(Mutation.setOriginText(input)),
+                translate(text: input)
             ])
         case .speechRecognitionAvailabiltyChanged(let isAvailable):
             return .just(Mutation.setIsMicrophoneButtonEnable(isAvailable))
+        case .originSendButtonTapped:
+            return .concat([
+                requestSendMessage(message: currentState.originText),
+                .just(Mutation.clearTextView)
+            ])
+        case .translatedSendButtonTapped:
+            return .concat([
+                requestSendMessage(message: currentState.translatedText),
+                .just(Mutation.clearTextView)
+            ])
         }
     }
     
@@ -71,6 +86,9 @@ final class SpeechViewReactor: Reactor {
             state.originText = output
         case .setIsMicrophoneButtonEnable(let isEnable):
             state.isMicrophoneButtonEnable = isEnable
+        case .clearTextView:
+            state.originText = ""
+            state.translatedText = ""
         }
         return state
     }
@@ -95,5 +113,14 @@ final class SpeechViewReactor: Reactor {
                                                             text: text))
             .asObservable()
             .map { Mutation.setTranslatedText($0) }
+    }
+    
+    private func requestSendMessage(message: String) -> Observable<Mutation> {
+        return networkService.sendMessage(text: message,
+                                          source: userData.language.code,
+                                          userId: userData.id,
+                                          roomId: roomID)
+            .asObservable()
+            .map { _ in Mutation.clearTextView }
     }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Common/Util/RevisionedData.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Common/Util/RevisionedData.swift
@@ -1,0 +1,32 @@
+//
+//  RevisionedData.swift
+//  PapagoTalk
+//
+//  Created by Byoung-Hwi Yoon on 2020/12/04.
+//
+
+import Foundation
+
+struct RevisionedData<T>: Equatable {
+    static func == (lhs: RevisionedData, rhs: RevisionedData) -> Bool {
+        lhs.revision == rhs.revision
+    }
+    
+    fileprivate let revision: UInt
+    let data: T?
+    
+    init(revision: UInt, data: T?) {
+        self.revision = revision
+        self.data = data
+    }
+    
+    init(data: T?) {
+        self.revision = 0
+        self.data = data
+    }
+}
+
+extension RevisionedData {
+    func update(_ data: T?) -> RevisionedData {
+        return RevisionedData<T>(revision: self.revision + 1, data: data) }
+}


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- ReactorKit에서 State가 동일하게 변화하는 경우를 감지하는데 어려움 발생
         - State가 동일하더라도 내부적으로 값을 변경시켜 바인딩 할 수 있는 객체 구현
- 메시지를 전송하기 위해서 음성인식 화면에 RoomID 전달
- 원문 및 번역 메시지 전송 버튼 바인딩
- 음성인식Reactor에 네트워크서비스 추가
- 버튼 클릭시 텍스트뷰 초기화

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 원문 전송 버튼을 클릭하였을 경우 원문 메시지가 전송되는가?
- [x] 번역 전송 버튼을 클릭하였을 경우 번역 메시지가 전송되는가?
- [x] 메시지가 전송된 이후에 테스트뷰가 초기화 되는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
