### PR TITLE
[Feature/#204] iOS 배포 전 NCP papago API로 변경 / 4개 국어 기능 추가 / 다크모드 색상 변경

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Assets.xcassets/MessageTextColor.colorset/Contents.json
+++ b/iOS/PapagoTalk/PapagoTalk/Assets.xcassets/MessageTextColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.961",
-          "green" : "0.569",
-          "red" : "0.329"
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "109",
-          "green" : "69",
-          "red" : "22"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/iOS/PapagoTalk/PapagoTalk/Assets.xcassets/PapagoGreen.colorset/Contents.json
+++ b/iOS/PapagoTalk/PapagoTalk/Assets.xcassets/PapagoGreen.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.518",
-          "green" : "0.894",
-          "red" : "0.439"
+          "blue" : "68",
+          "green" : "93",
+          "red" : "42"
         }
       },
       "idiom" : "universal"

--- a/iOS/PapagoTalk/PapagoTalk/Assets.xcassets/PapagoSkyBlue.colorset/Contents.json
+++ b/iOS/PapagoTalk/PapagoTalk/Assets.xcassets/PapagoSkyBlue.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.949",
-          "green" : "0.725",
-          "red" : "0.365"
+          "blue" : "110",
+          "green" : "80",
+          "red" : "27"
         }
       },
       "idiom" : "universal"

--- a/iOS/PapagoTalk/PapagoTalk/Base.lproj/Main.storyboard
+++ b/iOS/PapagoTalk/PapagoTalk/Base.lproj/Main.storyboard
@@ -422,42 +422,42 @@
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uzD-9A-Fmv">
                                         <rect key="frame" x="72" y="324.66666666666669" width="35" height="3"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="3" id="ibD-cT-511"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kPJ-zQ-aUv">
                                         <rect key="frame" x="115" y="324.66666666666669" width="35" height="3"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="3" id="R7U-CR-tx7"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eeJ-bB-zWY">
                                         <rect key="frame" x="158" y="324.66666666666669" width="35" height="3"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="3" id="2yR-dl-dPx"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y1s-iN-MLv">
                                         <rect key="frame" x="221" y="324.66666666666669" width="35" height="3"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="3" id="rgB-Wi-VYx"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qHt-r9-MN8">
                                         <rect key="frame" x="264" y="324.66666666666669" width="35" height="3"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="3" id="kjP-EE-jUy"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Dpj-ZR-ZTl">
                                         <rect key="frame" x="307" y="324.66666666666669" width="35" height="3"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="3" id="mTY-or-7gO"/>
                                         </constraints>

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell.swift
@@ -20,6 +20,7 @@ extension MessageCell {
     
     func configureMessage(of messageTextView: UITextView, with message: String) {
         messageTextView.text = message
+        messageTextView.textColor = UIColor.init(named: "MessageTextColor")
     }
     
     func configureTime(of timeLabel: UILabel, with timeStamp: Date) {

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/ReceivedMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/ReceivedMessageCell.swift
@@ -38,5 +38,3 @@ extension ReceivedMessageCell: MessageCell {
         nickNameLabel.text = nickName
     }
 }
-
-

--- a/iOS/PapagoTalk/PapagoTalk/Common/Enum/Language.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Common/Enum/Language.swift
@@ -10,6 +10,8 @@ import Foundation
 enum Language: String, Codable, CaseIterable {
     case korean
     case english
+    case french
+    case japanese
     
     var localizedText: String {
         switch self {
@@ -17,6 +19,10 @@ enum Language: String, Codable, CaseIterable {
             return Strings.korean
         case .english:
             return Strings.english
+        case .french:
+            return "프랑스어"
+        case .japanese:
+            return "일본어"
         }
     }
     
@@ -26,6 +32,10 @@ enum Language: String, Codable, CaseIterable {
             return "ko"
         case .english:
             return "en"
+        case .french:
+            return "fr"
+        case .japanese:
+            return "ja"
         }
     }
     
@@ -35,6 +45,10 @@ enum Language: String, Codable, CaseIterable {
             return Locale(identifier: "ko-KR")
         case .english:
             return Locale(identifier: "en-US")
+        case .french:
+            return Locale(identifier: "fr_KR")
+        case .japanese:
+            return Locale(identifier: "ja_KR")
         }
     }
     
@@ -44,6 +58,10 @@ enum Language: String, Codable, CaseIterable {
             return 0
         case .english:
             return 1
+        case .french:
+            return 2
+        case .japanese:
+            return 3
         }
     }
     
@@ -53,6 +71,10 @@ enum Language: String, Codable, CaseIterable {
             return .korean
         case "en":
             return .english
+        case "fr":
+            return .french
+        case "ja":
+            return .japanese
         default:
             return .english
         }

--- a/iOS/PapagoTalk/PapagoTalk/Common/Factory/ImageFactory.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Common/Factory/ImageFactory.swift
@@ -10,10 +10,31 @@ import Foundation
 struct ImageFactory: ImageFactoryProviding {
     
     private static let defaultImages = [
-        "https://kr.object.ncloudstorage.com/papagotalk/skyblue.png",
-        "https://kr.object.ncloudstorage.com/papagotalk/red.png",
-        "https://kr.object.ncloudstorage.com/papagotalk/orange.png",
-        "https://kr.object.ncloudstorage.com/papagotalk/gray.png"
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/1.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/2.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/3.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/4.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/5.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/6.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/7.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/8.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/9.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/10.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/11.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/12.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/13.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/14.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/15.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/16.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/17.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/18.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/19.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/20.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/21.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/22.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/23.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/24.png",
+        "https://kr.object.ncloudstorage.com/papagotalk/defaultimage/25.png"
     ]
     
     func randomImageURL() -> String {

--- a/iOS/PapagoTalk/PapagoTalk/Network/PapagoAPIManager.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Network/PapagoAPIManager.swift
@@ -39,22 +39,23 @@ final class PapagoAPIManager {
 }
 
 struct PapagoAPIRequest: HTTPRequest {
-    var url: URL = APIEndPoint.naverPapagoOpenAPI
-    var httpMethod: HTTPMethod = .post
-    var headers: [String: String] = [
-        "Content-Type": "application/json",
-        "X-Naver-Client-Id": APIEndPoint.naverPapagoOpenAPIclientID,
-        "X-Naver-Client-Secret": APIEndPoint.naverPapagoOpenAPIclientSecret
-    ]
-    
-    //  NCP
-    //    var url: URL = APIEndPoint.ncpPapagoAPI
+    // NaverDevelopers OpenAPI
+    //    var url: URL = APIEndPoint.naverPapagoOpenAPI
     //    var httpMethod: HTTPMethod = .post
     //    var headers: [String: String] = [
     //        "Content-Type": "application/json",
-    //        "X-NCP-APIGW-API-KEY-ID": APIEndPoint.ncpPapagoAPIclientID,
-    //        "X-NCP-APIGW-API-KEY": APIEndPoint.ncpPapagoAPIclientSecret
+    //        "X-Naver-Client-Id": APIEndPoint.naverPapagoOpenAPIclientID,
+    //        "X-Naver-Client-Secret": APIEndPoint.naverPapagoOpenAPIclientSecret
     //    ]
+    
+    //  NCP
+    var url: URL = APIEndPoint.ncpPapagoAPI
+    var httpMethod: HTTPMethod = .post
+    var headers: [String: String] = [
+        "Content-Type": "application/json",
+        "X-NCP-APIGW-API-KEY-ID": APIEndPoint.ncpPapagoAPIclientID,
+        "X-NCP-APIGW-API-KEY": APIEndPoint.ncpPapagoAPIclientSecret
+    ]
     
     var body: Data?
     


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- NaverCloudPlatform papagoAPI로 변경하여 배포합니다.
- 일본어, 프랑스어 번역기능을 지원합니다.
- 다크모드 색상을 변경하고 다크모드를 완전히 지원합니다.
- 랜덤 디폴트 이미지를 추가합니다. (총 25개)

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] NCP papgoAPI 번역 기능 작동 완료
- [x] 언어 추가된 언어 지원 정상 작동
- [x] 다크모드의 아름다움
- [x] 랜덤 디폴트 이미지를 추가된 것들 잘 적용 되는지 여부

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
