### PR TITLE
[Fix/#201] : 앱이 백그라운드 진입시 소켓통신 중단 문제 해결

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewReactor.swift
@@ -37,6 +37,7 @@ final class ChatViewReactor: Reactor {
     private let networkService: NetworkServiceProviding
     private let userData: UserDataProviding
     private let roomID: Int
+    private var socketObservable: Observable<Mutation>?
     
     let initialState: State
     
@@ -60,7 +61,7 @@ final class ChatViewReactor: Reactor {
         case .sendMessage(let message):
             return requestSendMessage(message: message)
         case .chatDrawerButtonTapped:
-            return Observable.just(Mutation.toggleDrawerState)
+            return .just(.toggleDrawerState)
         }
     }
     


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 앱이 백그라운드에 진입하였을 경우, 소켓연결이 disconnect되어 발생하는 문제로 인지하였으나, 테스트 결과 autoReconnect하는 것으로 확인
- 소켓 subscription을 observable로 변환하는 과정에서 error를 onError로 내려 스트림이 끊어지는 상황 인지
       - 소켓 subscription을 observable로 변환하는 과정에서 error를 내리지 않도록 변경
       - error시에는 연결 여부를 확인하고 reconnect하는 방식으로 대체

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 앱이 Background에 진입하고, 다시 Foreground로 돌아온 이후에도 소켓통신이 정상적으로 동작하는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
