### PR TITLE
[Feature/#211] 해당 룸의 사용자 정보를 구독/발행하는 API 추가

### DIFF
--- a/server/src/api/Room/createRoom/createRoom.ts
+++ b/server/src/api/Room/createRoom/createRoom.ts
@@ -16,7 +16,7 @@ export default {
       args: User,
     ): Promise<{ userId: number; roomId: number; code: string }> => {
       const { nickname, avatar, lang } = args;
-      const user = await prisma.user.create({
+      const newUser = await prisma.user.create({
         data: {
           nickname,
           lang,
@@ -28,14 +28,14 @@ export default {
         data: {
           users: {
             connect: {
-              id: user.id,
+              id: newUser.id,
             },
           },
           avatar: randomImage(),
           code: randomCode,
         },
       });
-      return { userId: user.id, roomId: newRoom.id, code: randomCode };
+      return { userId: newUser.id, roomId: newRoom.id, code: randomCode };
     },
   },
 };

--- a/server/src/api/Room/enterRoom/enterRoom.ts
+++ b/server/src/api/Room/enterRoom/enterRoom.ts
@@ -14,8 +14,9 @@ export default {
     enterRoom: async (
       _: any,
       { nickname, avatar, lang, code }: EnterInfo,
+      { pubsub }: any,
     ): Promise<{ userId: number; roomId: number }> => {
-      const result = await prisma.user.create({
+      const newUser = await prisma.user.create({
         data: {
           nickname,
           lang,
@@ -26,8 +27,8 @@ export default {
         },
         include: { rooms: true },
       });
-
-      return { userId: result.id, roomId: result.rooms[0].id };
+      pubsub.publish('NEW_USER', { newUser });
+      return { userId: newUser.id, roomId: newUser.rooms[0].id };
     },
   },
 };

--- a/server/src/api/User/newUser/newUser.graphql
+++ b/server/src/api/User/newUser/newUser.graphql
@@ -1,0 +1,3 @@
+type Subscription {
+  newUser(roomId: Int!): User
+}

--- a/server/src/api/User/newUser/newUser.ts
+++ b/server/src/api/User/newUser/newUser.ts
@@ -1,0 +1,15 @@
+import { withFilter } from 'graphql-subscriptions';
+
+export default {
+  Subscription: {
+    newUser: {
+      subscribe: withFilter(
+        (_: any, __: any, { pubsub }: any) => pubsub.asyncIterator('NEW_USER'),
+        async (payload, variables): Promise<boolean> => {
+          if (payload.newUser.rooms[0].id === variables.roomId) return true;
+          return false;
+        },
+      ),
+    },
+  },
+};


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- Issue #211 
- Room 컴포넌트에서 입장, 퇴장하는 사용자에 대한 정보를 실시간으로 관리할 수 있게 하기 위한 API가 필요합니다.
- GraphQL의 Subscription을 이용합니다.

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] Room에 사용자의 입/퇴장 정보가 실시간으로 반영되는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
