### PR TITLE
[Feature/#246] iOS Message subscibe 중복 호출 문제 해결

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Network/ApolloNetworkService.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Network/ApolloNetworkService.swift
@@ -73,9 +73,7 @@ class ApolloNetworkService: NetworkServiceProviding {
                             observer.onNext(data)
                         }
                     case .failure:
-                        if !(self?.webSocketTransport.isConnected() ?? false) {
-                            self?.webSocketTransport.resumeWebSocketConnection()
-                        }
+                        self?.reconnect()
                     }
                 }
             )
@@ -158,6 +156,12 @@ class ApolloNetworkService: NetworkServiceProviding {
             return Disposables.create {
                 cancellable?.cancel()
             }
+        }
+    }
+    
+    func reconnect() {
+        if !webSocketTransport.isConnected() {
+            webSocketTransport.resumeWebSocketConnection()
         }
     }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Network/NetworkServiceProviding.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Network/NetworkServiceProviding.swift
@@ -23,4 +23,6 @@ protocol NetworkServiceProviding {
     func createRoom(user: User) -> Maybe<CreateRoomResponse>
     
     func getUserList(of roomID: Int) -> Maybe<FindRoomByIdQuery.Data>
+    
+    func reconnect()
 }


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- ViewWillAppear가 중복호출 되었을 시 메시지 구독이 중복으로 일어나는 현상 해결
- ViewWillAppear시 구독을 시작하고 플래그값을 변경
- 이미 구독중인 경우에는 커넥션 상태를 확인하고 reconnect하는 방식으로 변경

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 메시지 중복 구독현상이 발생하지 않는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
