### PR TITLE
[Feature/#247] iOS 채팅화면 오토스크롤 이슈 해결

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
@@ -80,11 +80,8 @@ final class ChatViewController: UIViewController, StoryboardView {
             .disposed(by: disposeBag)
         
         reactor.state.map { $0.messageBox.messages }
-            .do(afterNext: { [weak self] in
-                guard let currentMessageType = $0.last?.type,
-                      currentMessageType == .sent else {
-                    return
-                }
+            .observeOn(MainScheduler.instance)
+            .do(afterNext: { [weak self] _ in
                 self?.scrollToLastMessage()
             })
             .bind(to: chatCollectionView.rx.items) { [weak self] (_, row, element) in

--- a/iOS/PapagoTalk/PapagoTalk/Home/HomeViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Home/HomeViewReactor.swift
@@ -110,8 +110,8 @@ final class HomeViewReactor: Reactor {
         let needShake = nickName.count > maxLength
 
         return .concat([
-            .just(Mutation.shakeNickNameTextField(needShake)),
-            .just(Mutation.setNickName(String(nickName.prefix(maxLength))))
+            .just(Mutation.setNickName(String(nickName.prefix(maxLength)))),
+            .just(Mutation.shakeNickNameTextField(needShake))
         ])
     }
     


### PR DESCRIPTION

## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 메시지수신 발신시 모두 마지막 메시지로 스크롤 하는 방식으로 변경
- 스크롤하지 않을 시 중간지점에서 뷰를 다시그리면서 스크롤 위치가 변경됨
- 해당 이슈 해결시 상단 메시지를 확인중에는 수신시 스크롤하지 않는 것으로 변경예정

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 새로운 메시지가 추가되었을 경우 마지막 메시지로 스크롤되는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
