### PR TITLE
[Feature/#267] 해당 룸의 사용자 삭제 여부를 구독하는 API 생성

### DIFF
--- a/server/src/api/User/deleteUser/deleteUser.graphql
+++ b/server/src/api/User/deleteUser/deleteUser.graphql
@@ -1,3 +1,12 @@
 type Mutation {
   deleteUser: Boolean!
 }
+
+type deleteUserResponse {
+  id: Int!
+  roomId: Int!
+}
+
+type Subscription {
+  deleteUser(roomId: Int!): deleteUserResponse
+}

--- a/server/src/api/User/deleteUser/deleteUser.ts
+++ b/server/src/api/User/deleteUser/deleteUser.ts
@@ -1,10 +1,15 @@
 import { PrismaClient } from '@prisma/client';
+import { withFilter } from 'graphql-subscriptions';
 
 const prisma = new PrismaClient();
 
 export default {
   Mutation: {
-    deleteUser: async (_: any, __: any, { request, isAuthenticated }: any): Promise<boolean> => {
+    deleteUser: async (
+      _: any,
+      __: any,
+      { pubsub, request, isAuthenticated }: any,
+    ): Promise<boolean> => {
       isAuthenticated(request);
       const { id: userId, roomId } = request.user;
       await prisma.$queryRaw`DELETE FROM User WHERE id = ${userId}`;
@@ -12,7 +17,20 @@ export default {
       if (!restUser[0]['COUNT(*)']) {
         await prisma.$queryRaw`DELETE FROM Room WHERE id = ${roomId}`;
       }
+      pubsub.publish('DELETE_USER', { deleteUser: { id: userId, roomId } });
       return true;
+    },
+  },
+
+  Subscription: {
+    deleteUser: {
+      subscribe: withFilter(
+        (_: any, __: any, { pubsub }: any) => pubsub.asyncIterator('DELETE_USER'),
+        async (payload, variables): Promise<boolean> => {
+          if (payload.deleteUser.roomId === variables.roomId) return true;
+          return false;
+        },
+      ),
     },
   },
 };


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- Issue #267
- 사용자 삭제 mutation 수행 후 호출되는 subscription api 생성

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
