### PR TITLE
[Feature/#268] 채팅방에서 사용자의 입/퇴장 여부를 구독

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -34,6 +34,7 @@ module.exports = {
           ['@routes', './src/routes'],
           ['@styles', './src/styles'],
           ['@utils', './src/utils'],
+          ['@hooks', './src/hooks'],
         ],
       },
     },

--- a/client/src/components/Room/Header/index.tsx
+++ b/client/src/components/Room/Header/index.tsx
@@ -3,16 +3,27 @@ import { useHistory } from 'react-router-dom';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { Hamburger, Copy, Door } from '@components/Icons';
 import { AvatarStack, Avatar } from '@primer/components';
+import { useMutation } from '@apollo/client';
+import { DELETE_USER } from '@/queries/user.queries';
+import { User } from '@/generated/types';
 import S from './style';
 
 interface Props {
   visible: boolean;
   setVisible: React.Dispatch<React.SetStateAction<boolean>>;
   code: string;
+  users: User[];
 }
 
-const Header: React.FC<Props> = ({ visible, setVisible, code }) => {
+const Header: React.FC<Props> = ({ visible, setVisible, code, users }) => {
   const history = useHistory();
+  const [deleteUser] = useMutation(DELETE_USER);
+
+  const leaveRoom = async () => {
+    await deleteUser();
+    localStorage.removeItem('token');
+    history.push('/');
+  };
 
   return (
     <S.Wrapper>
@@ -31,18 +42,16 @@ const Header: React.FC<Props> = ({ visible, setVisible, code }) => {
       </CopyToClipboard>
       <S.RightWrapper>
         <AvatarStack alignRight>
-          <Avatar
-            style={{ width: '24px', height: '24px' }}
-            alt="Primer"
-            src="https://avatars.githubusercontent.com/primer"
-          />
-          <Avatar
-            style={{ width: '24px', height: '24px' }}
-            alt="GitHub"
-            src="https://avatars.githubusercontent.com/github"
-          />
+          {users.map((user) => (
+            <Avatar
+              key={user.id}
+              style={{ width: '24px', height: '24px' }}
+              alt={user.nickname}
+              src={user.avatar}
+            />
+          ))}
         </AvatarStack>
-        <S.DoorButton onClick={() => history.push('/')}>
+        <S.DoorButton onClick={leaveRoom}>
           <Door size={24} />
         </S.DoorButton>
       </S.RightWrapper>

--- a/client/src/components/Room/SideBar/index.tsx
+++ b/client/src/components/Room/SideBar/index.tsx
@@ -1,31 +1,16 @@
 import React from 'react';
 import { Hamburger } from '@components/Icons';
-import { useQuery } from '@apollo/client';
-import { ROOM_BY_ID } from '@/queries/room.queires';
+import { User } from '@/generated/types';
 import S from './style';
 
 interface Props {
   visible: boolean;
   setVisible: React.Dispatch<React.SetStateAction<boolean>>;
-  roomId: number;
+  users: User[];
 }
 
-interface User {
-  id: number;
-  nickname: string;
-  avatar: string;
-  lang: string;
-}
-
-const SideBar: React.FC<Props> = ({ visible, setVisible, roomId }) => {
+const SideBar: React.FC<Props> = ({ visible, setVisible, users }) => {
   if (!visible) return null;
-
-  const { loading, error, data } = useQuery(ROOM_BY_ID, {
-    variables: { id: roomId },
-  });
-  if (loading) return null;
-
-  const { users }: { users: User[] } = data.roomById;
 
   return (
     <>

--- a/client/src/hooks/useMessages.ts
+++ b/client/src/hooks/useMessages.ts
@@ -13,7 +13,7 @@ interface QueryReturnType {
   loading: boolean;
 }
 
-const useUserList = ({ roomId, page, lang }: Variables): QueryReturnType => {
+const useMessages = ({ roomId, page, lang }: Variables): QueryReturnType => {
   const { data, loading, subscribeToMore } = useQuery(ALL_MESSAGES_BY_ID, {
     variables: {
       id: roomId,
@@ -45,4 +45,4 @@ const useUserList = ({ roomId, page, lang }: Variables): QueryReturnType => {
   return { data, loading };
 };
 
-export default useUserList;
+export default useMessages;

--- a/client/src/hooks/useUsers.ts
+++ b/client/src/hooks/useUsers.ts
@@ -1,0 +1,71 @@
+import React, { useEffect } from 'react';
+import { NEW_USER, SUBSCRIBE_DELETE_USER } from '@/queries/user.queries';
+import { useQuery } from '@apollo/client';
+import { User } from '../generated/types';
+import { ROOM_BY_ID } from '../queries/room.queires';
+
+interface Variables {
+  roomId: number;
+}
+
+interface QueryReturnType {
+  data: any;
+  loading: boolean;
+}
+
+const useUsers = ({ roomId }: Variables): QueryReturnType => {
+  const { data, loading, subscribeToMore } = useQuery(ROOM_BY_ID, {
+    variables: {
+      id: roomId,
+    },
+  });
+
+  useEffect(() => {
+    const unsubscribe = subscribeToMore({
+      document: NEW_USER,
+      variables: { roomId },
+      updateQuery: (prev, { subscriptionData }) => {
+        if (!subscriptionData.data) return prev;
+        const { newUser } = subscriptionData.data;
+        return {
+          ...prev,
+          roomById: {
+            ...prev.roomById,
+            users: [...prev.roomById.users, newUser],
+          },
+        };
+      },
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToMore({
+      document: SUBSCRIBE_DELETE_USER,
+      variables: { roomId },
+      updateQuery: (prev, { subscriptionData }) => {
+        if (!subscriptionData.data) return prev;
+        const { deleteUser } = subscriptionData.data;
+        const newList = prev.roomById.users.filter(
+          (user: User) => user.id !== deleteUser.id,
+        );
+        return {
+          ...prev,
+          roomById: {
+            ...prev.roomById,
+            users: newList,
+          },
+        };
+      },
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  return { data, loading };
+};
+
+export default useUsers;

--- a/client/src/queries/user.queries.ts
+++ b/client/src/queries/user.queries.ts
@@ -1,0 +1,26 @@
+import { gql } from '@apollo/client';
+
+export const NEW_USER = gql`
+  subscription newUser($roomId: Int!) {
+    newUser(roomId: $roomId) {
+      id
+      avatar
+      nickname
+      lang
+    }
+  }
+`;
+
+export const DELETE_USER = gql`
+  mutation {
+    deleteUser
+  }
+`;
+
+export const SUBSCRIBE_DELETE_USER = gql`
+  subscription deleteUser($roomId: Int!) {
+    deleteUser(roomId: $roomId) {
+      id
+    }
+  }
+`;

--- a/client/src/routes/Room.tsx
+++ b/client/src/routes/Room.tsx
@@ -1,12 +1,11 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useState } from 'react';
 import { RouteComponentProps, useLocation } from 'react-router-dom';
-import { NEW_MESSAGE, ALL_MESSAGES_BY_ID } from '@queries/messege.queries';
-import { useQuery } from '@apollo/client';
 import ChatLog from '@components/ChatLog';
 import Header from '@components/Room/Header';
 import SideBar from '@components/Room/SideBar';
 import Input from '@components/Room/Input';
 import useMessages from '@/hooks/useMessages';
+import useUsers from '@/hooks/useUsers';
 
 interface MatchParams {
   id: string;
@@ -22,21 +21,31 @@ const Room: FC<RouteComponentProps<MatchParams>> = ({ match }) => {
   const roomId = +match.params.id;
   const location = useLocation<LocationState>();
   const { lang, code } = location.state;
-  const { data, loading } = useMessages({
+  const { data: messageData, loading: messageLoading } = useMessages({
     roomId,
     page: 1,
     lang,
   });
+  const { data: usersData, loading: usersLoading } = useUsers({ roomId });
 
   const [visible, setVisible] = useState<boolean>(false);
 
-  if (loading) return <div>Loading!</div>;
+  if (messageLoading || usersLoading) return <div>Loading!</div>;
 
   return (
     <>
-      <Header visible={visible} setVisible={setVisible} code={code} />
-      <SideBar visible={visible} setVisible={setVisible} roomId={roomId} />
-      <ChatLog messages={data.allMessagesById.messages} />
+      <Header
+        visible={visible}
+        setVisible={setVisible}
+        code={code}
+        users={usersData.roomById.users}
+      />
+      <SideBar
+        visible={visible}
+        setVisible={setVisible}
+        users={usersData.roomById.users}
+      />
+      <ChatLog messages={messageData.allMessagesById.messages} />
       <Input />
     </>
   );

--- a/client/src/routes/Room.tsx
+++ b/client/src/routes/Room.tsx
@@ -21,7 +21,7 @@ const Room: FC<RouteComponentProps<MatchParams>> = ({ match }) => {
   const roomId = +match.params.id;
   const location = useLocation<LocationState>();
   const { lang, code } = location.state;
-  const { data: messageData, loading: messageLoading } = useMessages({
+  const { data: messagesData, loading: messagesLoading } = useMessages({
     roomId,
     page: 1,
     lang,
@@ -30,7 +30,7 @@ const Room: FC<RouteComponentProps<MatchParams>> = ({ match }) => {
 
   const [visible, setVisible] = useState<boolean>(false);
 
-  if (messageLoading || usersLoading) return <div>Loading!</div>;
+  if (messagesLoading || usersLoading) return <div>Loading!</div>;
 
   return (
     <>
@@ -45,7 +45,7 @@ const Room: FC<RouteComponentProps<MatchParams>> = ({ match }) => {
         setVisible={setVisible}
         users={usersData.roomById.users}
       />
-      <ChatLog messages={messageData.allMessagesById.messages} />
+      <ChatLog messages={messagesData.allMessagesById.messages} />
       <Input />
     </>
   );

--- a/client/src/routes/Room.tsx
+++ b/client/src/routes/Room.tsx
@@ -4,8 +4,8 @@ import ChatLog from '@components/ChatLog';
 import Header from '@components/Room/Header';
 import SideBar from '@components/Room/SideBar';
 import Input from '@components/Room/Input';
-import useMessages from '@/hooks/useMessages';
-import useUsers from '@/hooks/useUsers';
+import useMessages from '@hooks/useMessages';
+import useUsers from '@hooks/useUsers';
 
 interface MatchParams {
   id: string;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -25,6 +25,7 @@
       "@utils/*": ["src/utils/*"],
       "@queries/*": ["src/queries/*"],
       "@generated/*": ["src/generated/*"],
+      "@hooks/*": ["src/hooks/*"],
     }
   },
   "exclude": ["node_modules"],

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -21,6 +21,7 @@ module.exports = {
       '@utils': path.resolve(__dirname, 'src/utils'),
       '@queries': path.resolve(__dirname, 'src/queries'),
       '@generated': path.resolve(__dirname, 'src/generated'),
+      '@hooks': path.resolve(__dirname, 'src/hooks'),
     },
   },
 


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- Issue #268 
- server에서 구현한 사용자 삭제 여부를 구독하는 deleteUser subscription API를 client side에 적용합니다.

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 사용자의 입장 여부가 바로 화면에 반영되는가?
- [x] 사용자의 퇴장 여부가 바로 화면에 반영되는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
