### PR TITLE
[Feature/#252] iOS ChatDrawer panGesture 구조 개선

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Base.lproj/Main.storyboard
+++ b/iOS/PapagoTalk/PapagoTalk/Base.lproj/Main.storyboard
@@ -827,7 +827,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WxS-q5-ims" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1011.5942028985507" y="922.76785714285711"/>
+            <point key="canvasLocation" x="1048" y="883"/>
         </scene>
         <!--Language Selection View Controller-->
         <scene sceneID="Nc3-Cl-Xbg">

--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
@@ -19,6 +19,7 @@ final class ChatViewController: UIViewController, StoryboardView {
     @IBOutlet weak var chatDrawerButton: UIBarButtonItem!
     @IBOutlet private weak var bottomConstraint: NSLayoutConstraint!
     
+    private var chatDrawerObserver = BehaviorRelay(value: false)
     weak var coordinator: ChatCoordinating?
     var microphoneButton: MicrophoneButton!
     var disposeBag = DisposeBag()
@@ -64,6 +65,11 @@ final class ChatViewController: UIViewController, StoryboardView {
         
         chatDrawerButton.rx.tap
             .map { Reactor.Action.chatDrawerButtonTapped }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
+        chatDrawerObserver.filter { $0 }
+            .map { _ in Reactor.Action.chatDrawerButtonTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
     }
@@ -163,7 +169,7 @@ final class ChatViewController: UIViewController, StoryboardView {
         if isPresent {
             hideKeyboard()
         }
-        isPresent ? coordinator?.presentDrawer(from: self) : dismissDrawer()
+        isPresent ? coordinator?.presentDrawer(from: self, with: chatDrawerObserver) : dismissDrawer()
     }
     
     private func dismissDrawer() {

--- a/iOS/PapagoTalk/PapagoTalk/ChatDrawer/ChatDrawerViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/ChatDrawer/ChatDrawerViewController.swift
@@ -194,25 +194,25 @@ final class ChatDrawerViewController: UIViewController, StoryboardView {
         runningAnimations.append(blurAnimator)
     }
     
-    // MARK: - ChatDrawer PanGesture
-    
     private func chatDrawerPanned(recognizer: UIPanGestureRecognizer) {
-        let velocity = recognizer.velocity(in: view)
-
-        guard abs(velocity.x) > abs(velocity.y), let superview = view.superview else {
+        guard let superview = view.superview else {
             return
         }
         
-        let translation = recognizer.translation(in: view)
+        let velocity = recognizer.velocity(in: view)
         let superviewWidth = superview.frame.width
         let viewWidth = view.frame.width
-        var newX = view.center.x + translation.x
         
-        if newX + viewWidth/2 < superviewWidth {
-            newX = superviewWidth - viewWidth/2
+        if abs(velocity.x) > abs(velocity.y) {
+            let translation = recognizer.translation(in: view)
+            var newX = view.center.x + translation.x
+            
+            if newX + viewWidth/2 < superviewWidth {
+                newX = superviewWidth - viewWidth/2
+            }
+            view.center.x = newX
+            recognizer.setTranslation(.zero, in: view)
         }
-        view.center.x = newX
-        recognizer.setTranslation(.zero, in: view)
         
         guard recognizer.state == .ended else {
             return
@@ -222,7 +222,7 @@ final class ChatDrawerViewController: UIViewController, StoryboardView {
             view.center.x = superviewWidth - viewWidth/2
             return
         }
-        configureAnimation(state: .closed, duration: 0.9)
+        chatDrawerObserver.accept(true)
     }
 }
 

--- a/iOS/PapagoTalk/PapagoTalk/Coordinator/ChatCoordinating.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Coordinator/ChatCoordinating.swift
@@ -6,8 +6,9 @@
 //
 
 import UIKit
+import RxCocoa
 
 protocol ChatCoordinating: class {
     func presentSpeech(from presentingViewController: UIViewController)
-    func presentDrawer(from presentingViewController: UIViewController)
+    func presentDrawer(from presentingViewController: UIViewController, with observer: BehaviorRelay<Bool>)
 }

--- a/iOS/PapagoTalk/PapagoTalk/Coordinator/ChatCoordinator.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Coordinator/ChatCoordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import RxCocoa
 
 final class ChatCoordinator: Coordinator {
     weak var parentCoordinator: MainCoordinating?
@@ -86,7 +87,7 @@ extension ChatCoordinator: ChatCoordinating {
         }
     }
     
-    func presentDrawer(from presentingViewController: UIViewController) {
+    func presentDrawer(from presentingViewController: UIViewController, with observer: BehaviorRelay<Bool>) {
         guard let roomID = roomID,
               let code = code else {
             return
@@ -104,7 +105,8 @@ extension ChatCoordinator: ChatCoordinating {
                                                     roomCode: code)
                 return ChatDrawerViewController(coder: coder,
                                                 reactor: reactor,
-                                                visualEffectView: visualEffectView)
+                                                visualEffectView: visualEffectView,
+                                                observer: observer)
             }
         )
         drawerViewController.completion = {


### PR DESCRIPTION
## 설명
> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- panGesture를 시작하면(begin) 애니메이션을 시작하고, interrupt를 통해 위치를 잡는 로직을 변경하였습니다.
- 일정부분 밖으로 나가면 close 애니메이션이 시작하도록 하였습니다.
- 그 외의 부분은 원래의 위치로 돌아오게 하였습니다.
- y값의 gesture에는 움직이지 않게 하였습니다.
- NavigationBar ChatDrawerButton과 panGesture, tapGesture의 DrawerState를 동기화 하였습니다.
- 기타 ChatDrawer gesture 관련 버그를 모두 해결하였습니다.

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] ChatDrawer PanGesture가 잘 작동하는가
- [x] 일정부분 이상 밖으로 나가면 애니메이션이 시작되는가
- [x] 일정 부분 이상 밖으로 안 나가면 원래 위치로 돌아오는가
- [x] y값의 gesture에는 움직이지 않는가
- [x] NavigationBar ChatDrawerButton과 gesture들이 동기화 되는가

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
