### PR TITLE
[Feature/#275] 채팅을 새로 작성하는 경우, 본인이 쓴 채팅이 오른쪽에 위치하도록 수정

### DIFF
--- a/client/src/components/ChatLog/Balloon.tsx
+++ b/client/src/components/ChatLog/Balloon.tsx
@@ -1,24 +1,26 @@
 import React, { FC } from 'react';
 import styled from 'styled-components';
 import { Theme } from '@styles/Theme';
-import { useUserState } from '@contexts/UserContext';
 
 interface Props {
-  author?: string;
+  isOrigin?: boolean;
   text?: string;
   originText?: string;
   translatedText?: string;
+  isLeft?: boolean;
 }
 
 interface ContainerProps {
   bgColor: string;
   color: string;
+  isLeft: boolean;
 }
 
 const Container = styled.div<ContainerProps>`
   width: 200px;
   height: fit-content;
   min-height: 50px;
+  margin-left: ${(props) => (props.isLeft ? '0.7rem' : '0')};
   padding: 0.5rem;
   color: ${(props) => props.color};
   background-color: ${(props) => props.bgColor};
@@ -28,45 +30,74 @@ const Container = styled.div<ContainerProps>`
   font-weight: 400;
 `;
 
-const Balloon: FC<Props> = ({ author, text, translatedText, originText }) => {
-  const { nickname } = useUserState();
+const Balloon: FC<Props> = ({
+  isOrigin,
+  text,
+  translatedText,
+  originText,
+  isLeft = false,
+}) => {
   if (text) {
-    if (nickname === author) {
+    if (isOrigin) {
       return (
-        <Container color={Theme.whiteColor} bgColor={Theme.blueColor}>
+        <Container
+          color={Theme.whiteColor}
+          bgColor={Theme.blueColor}
+          isLeft={isLeft}
+        >
           {text}
         </Container>
       );
     }
     return (
-      <Container color={Theme.blackColor} bgColor={Theme.lightGrayColor}>
+      <Container
+        color={Theme.blackColor}
+        bgColor={Theme.lightGrayColor}
+        isLeft={isLeft}
+      >
         {text}
       </Container>
     );
   }
   if (originText) {
-    if (nickname === author) {
+    if (isOrigin) {
       return (
-        <Container color={Theme.whiteColor} bgColor={Theme.blueColor}>
+        <Container
+          color={Theme.whiteColor}
+          bgColor={Theme.blueColor}
+          isLeft={isLeft}
+        >
           {originText}
         </Container>
       );
     }
     return (
-      <Container color={Theme.blackColor} bgColor={Theme.lightGrayColor}>
+      <Container
+        color={Theme.blackColor}
+        bgColor={Theme.lightGrayColor}
+        isLeft={isLeft}
+      >
         {originText}
       </Container>
     );
   }
-  if (nickname === author) {
+  if (isOrigin) {
     return (
-      <Container color={Theme.whiteColor} bgColor={Theme.blueColor}>
+      <Container
+        color={Theme.whiteColor}
+        bgColor={Theme.blueColor}
+        isLeft={isLeft}
+      >
         {translatedText}
       </Container>
     );
   }
   return (
-    <Container color={Theme.blackColor} bgColor={Theme.lightGrayColor}>
+    <Container
+      color={Theme.blackColor}
+      bgColor={Theme.lightGrayColor}
+      isLeft={isLeft}
+    >
       {translatedText}
     </Container>
   );

--- a/client/src/components/ChatLog/ChatRow.tsx
+++ b/client/src/components/ChatLog/ChatRow.tsx
@@ -51,51 +51,42 @@ const DoubleBubble = styled.div`
 `;
 
 const ChatRow: FC<Props> = ({ author, message, obj, createdAt }) => {
+  console.log('author, message, obj :>> ', author, message, obj);
   const { nickname, avatar } = useUserState();
   const isOrigin = nickname === author;
   return (
     <Wrapper isOrigin={isOrigin}>
-      {isOrigin ? (
-        <>
-          <Column>
-            <Info isOrigin={isOrigin}>
-              <Text>{message?.user.nickname}</Text>
-              <Text>{message?.createdAt}</Text>
-            </Info>
-            <Balloon author={author} originText={obj?.originText} />
-          </Column>
-          <Avatar size={50} profile={avatar} />
-        </>
-      ) : (
-        <>
-          <Avatar size={50} profile={message?.user.avatar} />
-          <Column>
-            {obj ? (
-              <>
-                <Info isOrigin={isOrigin}>
-                  <Text>{author}</Text>
-                  <Text>{createdAt}</Text>
-                </Info>
-                <DoubleBubble>
+      <>
+        {!isOrigin && <Avatar size={50} profile={message?.user.avatar} />}
+        <Column>
+          {obj ? (
+            <>
+              <Info isOrigin={isOrigin}>
+                <Text>{author}</Text>
+                <Text>{createdAt}</Text>
+              </Info>
+              <DoubleBubble>
+                <Balloon author={author} originText={obj?.originText} />
+                {obj?.originText === obj?.translatedText ? null : (
                   <Balloon
                     author={author}
                     translatedText={obj?.translatedText}
                   />
-                  <Balloon author={author} originText={obj?.originText} />
-                </DoubleBubble>
-              </>
-            ) : (
-              <>
-                <Info isOrigin={isOrigin}>
-                  <Text>{message?.user.nickname}</Text>
-                  <Text>{message?.createdAt}</Text>
-                </Info>
-                <Balloon author={author} text={message?.text} />
-              </>
-            )}
-          </Column>
-        </>
-      )}
+                )}
+              </DoubleBubble>
+            </>
+          ) : (
+            <>
+              <Info isOrigin={isOrigin}>
+                <Text>{message?.user.nickname}</Text>
+                <Text>{message?.createdAt}</Text>
+              </Info>
+              <Balloon author={author} text={message?.text} />
+            </>
+          )}
+        </Column>
+        {isOrigin && <Avatar size={50} profile={avatar} />}
+      </>
     </Wrapper>
   );
 };

--- a/client/src/components/ChatLog/ChatRow.tsx
+++ b/client/src/components/ChatLog/ChatRow.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { useUserState } from '@contexts/UserContext';
 import Avatar from '@components/Avatar';
 import { Message } from '@generated/types';
 import Balloon from './Balloon';
@@ -11,10 +11,8 @@ interface TranslatedMessage {
 }
 
 interface Props {
-  author?: string;
   message?: Message;
   obj?: TranslatedMessage;
-  createdAt?: string;
 }
 
 interface isOriginProps {
@@ -45,19 +43,20 @@ const Text = styled.span`
 const DoubleBubble = styled.div`
   display: flex;
   align-items: center;
-  div {
-    margin-right: 0.7rem;
-  }
 `;
 
-const ChatRow: FC<Props> = ({ author, message, obj, createdAt }) => {
-  console.log('author, message, obj :>> ', author, message, obj);
-  const { nickname, avatar } = useUserState();
-  const isOrigin = nickname === author;
+const ChatRow: FC<Props> = ({ message, obj }) => {
+  const location = useLocation<{ userId: number }>();
+  const { userId } = location.state;
+  const isOrigin = userId === message?.user.id;
+  const author = message?.user.nickname;
+  const createdAt = message?.createdAt;
+  const avatar = message?.user.avatar;
+
   return (
     <Wrapper isOrigin={isOrigin}>
       <>
-        {!isOrigin && <Avatar size={50} profile={message?.user.avatar} />}
+        {!isOrigin && <Avatar size={50} profile={avatar} />}
         <Column>
           {obj ? (
             <>
@@ -66,11 +65,12 @@ const ChatRow: FC<Props> = ({ author, message, obj, createdAt }) => {
                 <Text>{createdAt}</Text>
               </Info>
               <DoubleBubble>
-                <Balloon author={author} originText={obj?.originText} />
+                <Balloon isOrigin={isOrigin} originText={obj?.originText} />
                 {obj?.originText === obj?.translatedText ? null : (
                   <Balloon
-                    author={author}
+                    isOrigin={isOrigin}
                     translatedText={obj?.translatedText}
+                    isLeft
                   />
                 )}
               </DoubleBubble>
@@ -78,10 +78,10 @@ const ChatRow: FC<Props> = ({ author, message, obj, createdAt }) => {
           ) : (
             <>
               <Info isOrigin={isOrigin}>
-                <Text>{message?.user.nickname}</Text>
-                <Text>{message?.createdAt}</Text>
+                <Text>{author}</Text>
+                <Text>{createdAt}</Text>
               </Info>
-              <Balloon author={author} text={message?.text} />
+              <Balloon isOrigin={isOrigin} text={message?.text} />
             </>
           )}
         </Column>

--- a/client/src/components/ChatLog/index.tsx
+++ b/client/src/components/ChatLog/index.tsx
@@ -25,25 +25,11 @@ const ChatLog: FC<Props> = ({ messages }) => {
       {messages.map((message) => {
         try {
           const obj: TranslatedText = JSON.parse(message.text);
-          return (
-            <ChatRow
-              key={message.id}
-              obj={obj}
-              author={message.user.nickname}
-              createdAt={message.createdAt as string}
-              message={message}
-            />
-          );
+          return <ChatRow key={message.id} obj={obj} message={message} />;
         } catch {
           // TODO: Logic 수정 필요 return
         }
-        return (
-          <ChatRow
-            key={message.id}
-            message={message}
-            author={message.user.nickname}
-          />
-        );
+        return <ChatRow key={message.id} message={message} />;
       })}
     </Wrapper>
   );

--- a/client/src/components/Modal/index.tsx
+++ b/client/src/components/Modal/index.tsx
@@ -88,7 +88,7 @@ const Modal: FC<Props> = ({ visible, setVisible }) => {
   const onClickEnterRoom = async () => {
     const { data } = await enterRoomMutation();
     const roomId = data?.enterRoom.roomId;
-    const userId = data?.enterRoom.roomId;
+    const userId = data?.enterRoom.userId;
     if (typeof data?.enterRoom.token === 'string')
       localStorage.setItem('token', data.enterRoom.token);
     history.push({
@@ -96,8 +96,6 @@ const Modal: FC<Props> = ({ visible, setVisible }) => {
       state: {
         userId,
         code: pinValue,
-        nickname,
-        avatar,
         lang,
       },
     });

--- a/client/src/hooks/useMessages.ts
+++ b/client/src/hooks/useMessages.ts
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { ALL_MESSAGES_BY_ID, NEW_MESSAGE } from '@/queries/messege.queries';
 import { useQuery } from '@apollo/client';
 

--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -58,11 +58,9 @@ const Home: React.FC = () => {
     history.push({
       pathname: `/room/${roomId}`,
       state: {
-        userId,
-        code,
-        nickname,
-        avatar,
         lang,
+        code,
+        userId,
       },
     });
   };

--- a/client/src/routes/Room.tsx
+++ b/client/src/routes/Room.tsx
@@ -13,7 +13,6 @@ interface MatchParams {
 
 interface LocationState {
   lang: string;
-  userId: number;
   code: string;
 }
 


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- ChatRow 채팅 출력부분 수정
  - 원본과 번역본이 같은 경우 채팅 한개만 띄워주기
  - ChatRow.ts에 겹치는 부분 리팩토링
  - 메시가 원본-번역본 순서로 나열되도록 수정
- Refactor : 사용하지 않는 변수 제거 (Home.ts, Room.ts, Modal-index.ts)
- refresh 발생 시 본인 메시지 오른쪽에 출력
- 번역문이 있는 경우 margin-left를 주도록 Bolloon에 isLeft Props 추가
Issue #275

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [ ] refresh가 발생해도 본인의 메세지가 오른쪽에 위치하는가?
- [ ] 메세지가 원본 - 번역본 순서로 나열되어 화면에 출력되는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
