### PR TITLE
[Feature/#280] iOS  동일한 언어 사용자와의 대화시 UI처리

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Base.lproj/Main.storyboard
+++ b/iOS/PapagoTalk/PapagoTalk/Base.lproj/Main.storyboard
@@ -1039,8 +1039,8 @@
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </textView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 6:25" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hRr-JJ-sLX">
-                                                    <rect key="frame" x="253" y="67.5" width="51" height="14.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hRr-JJ-sLX">
+                                                    <rect key="frame" x="304" y="82" width="0.0" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1153,8 +1153,8 @@
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </textView>
-                                                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 8:13" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d8P-YL-lNQ">
-                                                    <rect key="frame" x="162" y="87.5" width="48.5" height="14.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d8P-YL-lNQ">
+                                                    <rect key="frame" x="162" y="102" width="0.0" height="0.0"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                     <color key="textColor" systemColor="systemGrayColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1162,6 +1162,7 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="btx-gT-koo" firstAttribute="top" secondItem="BHL-qx-p9o" secondAttribute="top" priority="999" constant="4" id="0ou-wv-zAf"/>
+                                                <constraint firstItem="zyP-S3-xoJ" firstAttribute="top" secondItem="ymh-Tr-sLT" secondAttribute="top" id="1qK-76-dgi"/>
                                                 <constraint firstItem="ymh-Tr-sLT" firstAttribute="top" secondItem="btx-gT-koo" secondAttribute="bottom" priority="999" constant="12" id="2Er-jt-ZyQ"/>
                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zyP-S3-xoJ" secondAttribute="trailing" constant="12" id="4eI-Jm-EzT"/>
                                                 <constraint firstItem="btx-gT-koo" firstAttribute="centerX" secondItem="BHL-qx-p9o" secondAttribute="centerX" id="6uf-0Z-95E"/>
@@ -1170,7 +1171,6 @@
                                                 <constraint firstItem="Y1i-KZ-Cbi" firstAttribute="leading" secondItem="ymh-Tr-sLT" secondAttribute="trailing" constant="10" id="Vhf-Vo-OJA"/>
                                                 <constraint firstItem="d8P-YL-lNQ" firstAttribute="leading" secondItem="Y1i-KZ-Cbi" secondAttribute="trailing" constant="10" id="ZKO-VM-glt"/>
                                                 <constraint firstAttribute="bottom" secondItem="Y1i-KZ-Cbi" secondAttribute="bottom" priority="999" constant="8" id="a8D-NX-4iU"/>
-                                                <constraint firstItem="zyP-S3-xoJ" firstAttribute="top" secondItem="btx-gT-koo" secondAttribute="bottom" priority="999" constant="12" id="bIP-yq-vCQ"/>
                                                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="ymh-Tr-sLT" secondAttribute="bottom" priority="999" constant="12" id="ez4-xq-Btw"/>
                                                 <constraint firstItem="Y1i-KZ-Cbi" firstAttribute="top" secondItem="zyP-S3-xoJ" secondAttribute="bottom" priority="999" constant="8" id="fNp-Cq-7ph"/>
                                                 <constraint firstItem="ymh-Tr-sLT" firstAttribute="leading" secondItem="BHL-qx-p9o" secondAttribute="leading" constant="12" id="moM-7G-GiF"/>
@@ -1184,8 +1184,12 @@
                                         <connections>
                                             <outlet property="dateBadge" destination="btx-gT-koo" id="Zh4-56-IP7"/>
                                             <outlet property="dateBadgeHeight" destination="gWW-lI-9B9" id="7mQ-oJ-tKI"/>
+                                            <outlet property="messageBubbleTail" destination="s0R-rB-fgy" id="BH4-L3-Qaj"/>
                                             <outlet property="messageTextView" destination="Y1i-KZ-Cbi" id="seu-1M-1nm"/>
+                                            <outlet property="messageTopInset" destination="fNp-Cq-7ph" id="nwX-5r-DNQ"/>
                                             <outlet property="nickNameLabel" destination="zyP-S3-xoJ" id="rwX-Ua-6Zr"/>
+                                            <outlet property="profileImageHeight" destination="blP-3z-br4" id="y36-Fl-S1h"/>
+                                            <outlet property="profileImageTopInset" destination="2Er-jt-ZyQ" id="dyd-jQ-2M7"/>
                                             <outlet property="profileImageView" destination="ymh-Tr-sLT" id="ekO-5O-I7y"/>
                                             <outlet property="timeLabel" destination="d8P-YL-lNQ" id="8cZ-We-Yrh"/>
                                         </connections>
@@ -1229,8 +1233,8 @@
                                                         </userDefinedRuntimeAttribute>
                                                     </userDefinedRuntimeAttributes>
                                                 </textView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오후 8:13" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mF7-5M-TlD">
-                                                    <rect key="frame" x="164" y="27" width="48.5" height="14.5"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mF7-5M-TlD">
+                                                    <rect key="frame" x="164" y="41.5" width="0.0" height="0.0"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" id="LLW-gC-he8"/>
                                                     </constraints>

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
@@ -49,7 +49,8 @@ final class MessageBox {
     private func setShouldImageShow(of newMessage: Message, comparedBy lastMessage: Message) -> Message {
         guard newMessage.type == .received,
               lastMessage.type == .received,
-              newMessage.sender.id == lastMessage.sender.id else {
+              newMessage.sender.id == lastMessage.sender.id,
+              DateFormatter.chatTimeFormat(of: newMessage.timeStamp) == DateFormatter.chatTimeFormat(of: lastMessage.timeStamp) else {
             return newMessage
         }
         var message = newMessage

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
@@ -29,7 +29,8 @@ final class MessageBox {
             return
         }
         message = setMessageIsFirst(of: message, comparedBy: lastMessage)
-        messages.append(message)
+        message = setShouldImageShow(of: message, comparedBy: lastMessage)
+        setShouldTimeShow(of: message, comparedBy: lastMessage)
     }
     
     func setMessageIsFirst(of newMessage: Message, comparedBy lastMessage: Message) -> Message {
@@ -43,5 +44,28 @@ final class MessageBox {
         var message = newMessage
         message.setType(by: currentUserID)
         return message
+    }
+    
+    private func setShouldImageShow(of newMessage: Message, comparedBy lastMessage: Message) -> Message {
+        guard newMessage.type == .received,
+              lastMessage.type == .received,
+              newMessage.sender.id == lastMessage.sender.id else {
+            return newMessage
+        }
+        var message = newMessage
+        message.shouldImageShow = false
+        return message
+    }
+    
+    private func setShouldTimeShow(of newMessage: Message, comparedBy lastMessage: Message) {
+        guard newMessage.sender.id == lastMessage.sender.id,
+              DateFormatter.chatTimeFormat(of: newMessage.timeStamp) == DateFormatter.chatTimeFormat(of: lastMessage.timeStamp) else {
+            messages.append(newMessage)
+            return
+        }
+        var lastMessage = lastMessage
+        lastMessage.shouldTimeShow = false
+        messages.removeLast()
+        messages.append(contentsOf: [lastMessage, newMessage])
     }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
@@ -30,7 +30,8 @@ struct MessageParser {
                                     timeStamp: time)
         messages.append(originMessage)
         
-        if newMessage.user.id != userData.id {
+        if newMessage.user.id != userData.id &&
+            Language.codeToLanguage(of: newMessage.user.lang) != userData.language {
             let translatedMessage = Message(id: newMessage.id,
                                             of: translateResult.translatedText,
                                             by: sender,

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/MessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/MessageCell.swift
@@ -23,8 +23,8 @@ extension MessageCell {
         messageTextView.textColor = UIColor.init(named: "MessageTextColor")
     }
     
-    func configureTime(of timeLabel: UILabel, with timeStamp: Date) {
-        timeLabel.text = convertToTimeFormat(of: timeStamp)
+    func configureTime(of timeLabel: UILabel, with timeStamp: Date, shouldShow: Bool) {
+        timeLabel.text = shouldShow ? convertToTimeFormat(of: timeStamp) : nil
     }
     
     private func convertToDateFormat(of timeStamp: Date) -> String {

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/ReceivedMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/ReceivedMessageCell.swift
@@ -16,15 +16,34 @@ final class ReceivedMessageCell: UICollectionViewCell {
     @IBOutlet private weak var messageTextView: UITextView!
     @IBOutlet private weak var timeLabel: UILabel!
     @IBOutlet weak var dateBadgeHeight: NSLayoutConstraint!
+    @IBOutlet weak var profileImageHeight: NSLayoutConstraint!
+    @IBOutlet weak var profileImageTopInset: NSLayoutConstraint!
+    @IBOutlet weak var messageTopInset: NSLayoutConstraint!
+    
+    @IBOutlet weak var messageBubbleTail: ReceivedMessageBubbleTail!
     
 }
 
 extension ReceivedMessageCell: MessageCell {
     func configureMessageCell(message: Message) {
         configureDate(of: dateBadge, dateBadgeHeight: dateBadgeHeight, with: message.timeStamp, isFirst: message.isFirstOfDay)
-        configureImage(with: message.sender.image)
-        configureNickName(with: message.sender.nickName)
         configureMessage(of: messageTextView, with: message.text)
+        configureTime(of: timeLabel, with: message.timeStamp, shouldShow: message.shouldTimeShow)
+        configureSenderInfo(image: message.sender.image,
+                            nickName: message.sender.nickName,
+                            shouldImageShow: message.shouldImageShow)
+    }
+    
+    private func configureSenderInfo(image: String, nickName: String, shouldImageShow: Bool) {
+        profileImageHeight.constant = shouldImageShow ? 42 : 0
+        profileImageTopInset.constant = shouldImageShow ? 12 : 0
+        messageTopInset.constant = shouldImageShow ? 8 : 0
+        messageBubbleTail.isHidden = !shouldImageShow
+        nickNameLabel.text = nil
+        if shouldImageShow {
+            configureImage(with: image)
+            configureNickName(with: nickName)
+        }
     }
     
     private func configureImage(with imageURL: String) {

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/SentMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/SentMessageCell.swift
@@ -19,6 +19,6 @@ extension SentMessageCell: MessageCell {
     func configureMessageCell(message: Message) {
         configureDate(of: dateBadge, dateBadgeHeight: dateBadgeHeight, with: message.timeStamp, isFirst: message.isFirstOfDay)
         configureMessage(of: messageTextView, with: message.text)
-        configureTime(of: timeLabel, with: message.timeStamp)
+        configureTime(of: timeLabel, with: message.timeStamp, shouldShow: message.shouldTimeShow)
     }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/TranslatedMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/TranslatedMessageCell.swift
@@ -15,6 +15,6 @@ final class TranslatedMessageCell: UICollectionViewCell {
 extension TranslatedMessageCell: MessageCell {
     func configureMessageCell(message: Message) {
         configureMessage(of: messageTextView, with: message.text)
-        configureTime(of: timeLabel, with: message.timeStamp)
+        configureTime(of: timeLabel, with: message.timeStamp, shouldShow: message.shouldTimeShow)
     }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
@@ -16,6 +16,8 @@ struct Message: Codable {
     var isFirstOfDay: Bool
     var type: MessageType
     var isTranslated: Bool
+    var shouldTimeShow: Bool = true
+    var shouldImageShow: Bool = true
     
     init(of text: String, by sender: User) {
         self.id = nil


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 동일한 언어 사용자와의 대화시 무의미한 번역텍스트 출력되지 않도록 변경
- 출력방식 변경에 의한 UI변경
    - 같은 유저가 연속적으로 입력 시 프로필 사진과 닉네임 한번만 출력
    - 분단위로 시간이 변경되었을 경우에만 시간 출력
    - 시간이 바뀌었을 때는 프로필 사진과 닉네임 다시 출력

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 메시지 발신자가 동일한 언어 사용자라면 번역메시지가 출력되지 않는가?
- [x] UI가 이전보다 개선되었는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)

<img width="360" alt="스크린샷 2020-12-08 오후 5 57 30" src="https://user-images.githubusercontent.com/48614208/101461939-e8d70400-397e-11eb-9a68-681b28df5f6a.png">