### PR TITLE
[Feature/#278] 채팅화면 음성인식 버튼 오류 수정

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MicrophoneButton.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MicrophoneButton.swift
@@ -33,6 +33,7 @@ final class MicrophoneButton: RoundShadowButton {
     }
     
     private var latestCenter: CGPoint?
+    private var latestCenterForKeyboard: CGPoint?
     private let disposeBag = DisposeBag()
     
     var mode: ContentsMode = .small {
@@ -141,7 +142,7 @@ final class MicrophoneButton: RoundShadowButton {
             .map { _ in Void.self }
             .asDriver(onErrorJustReturn: Void.self)
             .drive(onNext: { [weak self] _ in
-                self?.moveToLatest()
+                self?.keyboardWillHide()
             })
             .disposed(by: disposeBag)
     }
@@ -181,10 +182,16 @@ final class MicrophoneButton: RoundShadowButton {
         let yBound = keyboardOriginY - superview.frame.minY - frame.height/2 - 50
         let originCenter = center
         if center.y >= yBound {
-            latestCenter = originCenter
+            latestCenterForKeyboard = originCenter
             UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) { [weak self] in
                 self?.center = CGPoint(x: originCenter.x, y: yBound - 10)
             }
+        }
+    }
+    
+    private func keyboardWillHide() {
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) { [weak self] in
+            self?.center = self?.latestCenterForKeyboard ?? .zero
         }
     }
 }


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 음성인식중 키보드가 올라왔을시, 최근 좌표를 공유하여 오류 발생
   - 최근좌표가 중앙에서 y좌표만 추가되어, 음성인식 화면이 닫힌 후 중앙에 위치
- 최근 좌표를 별도로 저장하여 문제 해결


## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 음성인식 화면에서 키보드가 올라온 이후에도, 음성인식화면 종료 후 버튼이 정상적인 좌표로 되돌아가는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
