### PR TITLE
[Fix/#309] apollo react hooks의 caching problem 해결

### DIFF
--- a/client/src/components/Room/Header/index.tsx
+++ b/client/src/components/Room/Header/index.tsx
@@ -6,6 +6,7 @@ import { AvatarStack, Avatar } from '@primer/components';
 import { useMutation } from '@apollo/client';
 import { DELETE_USER } from '@/queries/user.queries';
 import { User } from '@/generated/types';
+import client from '@/apollo/Client';
 import S from './style';
 
 interface Props {
@@ -20,9 +21,10 @@ const Header: React.FC<Props> = ({ visible, setVisible, code, users }) => {
   const [deleteUser] = useMutation(DELETE_USER);
 
   const leaveRoom = async () => {
+    history.push('/');
     await deleteUser();
     localStorage.removeItem('token');
-    history.push('/');
+    client.resetStore();
   };
 
   return (


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- Issue #309
- 아폴로에서 기본적으로 제공하는 fetch policy에 의한 cache problem 해결
- 퇴장 시 cache reset

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [ ] 퇴장 후 refresh 없이 다른 채팅방에 입장했을 때에 기존의 데이터가 반영되지 않는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

[아폴로 공식 문서](https://www.apollographql.com/docs/react/networking/authentication/#reset-store-on-logout)

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
