### PR TITLE
[Feature/#312] 서버 언어 감지 기능 구현에 따른 iOS 메시지 수신 로직 변경

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
@@ -16,8 +16,8 @@ final class ChatViewController: UIViewController, StoryboardView {
     @IBOutlet private weak var inputBarTextViewHeight: NSLayoutConstraint!
     @IBOutlet private weak var chatCollectionView: UICollectionView!
     @IBOutlet private weak var sendButton: UIButton!
-    @IBOutlet weak var chatDrawerButton: UIBarButtonItem!
     @IBOutlet private weak var bottomConstraint: NSLayoutConstraint!
+    @IBOutlet weak var chatDrawerButton: UIBarButtonItem!
     
     private var chatDrawerObserver = BehaviorRelay(value: false)
     private var micButtonSizeObserver: BehaviorRelay<MicButtonSize>

--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewReactor.swift
@@ -97,7 +97,9 @@ final class ChatViewReactor: Reactor {
     private func subscribeMessages() -> Observable<Mutation> {
         return networkService.getMessage(roomId: roomID, language: userData.language)
             .compactMap { $0.newMessage }
-            .compactMap { [weak self] in self?.messageParser.parse(newMessage: $0) }
+            .compactMap { [weak self] in
+                self?.messageParser.parse(newMessage: $0)
+            }
             .map { Mutation.appendNewMessage($0) }
     }
     

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
@@ -50,7 +50,8 @@ final class MessageBox {
         guard newMessage.type == .received,
               lastMessage.type == .received,
               newMessage.sender.id == lastMessage.sender.id,
-              DateFormatter.chatTimeFormat(of: newMessage.timeStamp) == DateFormatter.chatTimeFormat(of: lastMessage.timeStamp) else {
+              DateFormatter.chatTimeFormat(of: newMessage.timeStamp) == DateFormatter.chatTimeFormat(of: lastMessage.timeStamp)
+        else {
             return newMessage
         }
         var message = newMessage

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
@@ -32,8 +32,9 @@ struct MessageParser: MessageParseProviding {
         messages.append(originMessage)
         
         let messageLanguage = Language.codeToLanguage(of: newMessage.source)
+        let setting = false
         
-        guard messageLanguage != userData.language else {
+        guard messageLanguage != userData.language || messageLanguage != sender.language || setting else {
             return messages
         }
         
@@ -48,16 +49,3 @@ struct MessageParser: MessageParseProviding {
         return messages
     }
 }
-
-/*
- if newMessage.user.id != userData.id &&
-     Language.codeToLanguage(of: newMessage.user.lang) != userData.language {
-     let translatedMessage = Message(id: newMessage.id,
-                                     of: translatedResult.translatedText,
-                                     by: sender,
-                                     language: userData.language.code,
-                                     timeStamp: timeStamp,
-                                     isTranslated: true)
-     messages.append(translatedMessage)
- }
-*/

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
@@ -13,33 +13,51 @@ struct MessageParser: MessageParseProviding {
     
     func parse(newMessage: GetMessageSubscription.Data.NewMessage) -> [Message] {
         guard let timeStamp = newMessage.createdAt,
-              let json = newMessage.text.data(using: .utf8),
-              let translateResult: TranslatedResult = try? json.decoded() else {
+              let data = newMessage.text.data(using: .utf8),
+              let translatedResult: TranslatedResult = try? data.decoded()
+        else {
             return []
         }
+        
         var messages = [Message]()
-        let time = String(timeStamp.prefix(10))
         let sender = User(id: newMessage.user.id,
                           nickName: newMessage.user.nickname,
                           image: newMessage.user.avatar,
                           language: Language.codeToLanguage(of: newMessage.user.lang))
         let originMessage = Message(id: newMessage.id,
-                                    of: translateResult.originText,
+                                    of: translatedResult.originText,
                                     by: sender,
                                     language: newMessage.source,
-                                    timeStamp: time)
+                                    timeStamp: timeStamp)
         messages.append(originMessage)
         
-        if newMessage.user.id != userData.id &&
-            Language.codeToLanguage(of: newMessage.user.lang) != userData.language {
-            let translatedMessage = Message(id: newMessage.id,
-                                            of: translateResult.translatedText,
-                                            by: sender,
-                                            language: userData.language.code,
-                                            timeStamp: time,
-                                            isTranslated: true)
-            messages.append(translatedMessage)
+        let messageLanguage = Language.codeToLanguage(of: newMessage.source)
+        
+        guard messageLanguage != userData.language else {
+            return messages
         }
+        
+        let translatedMessage = Message(id: newMessage.id,
+                                        of: translatedResult.translatedText,
+                                        by: sender,
+                                        language: newMessage.source,
+                                        timeStamp: timeStamp,
+                                        isTranslated: true)
+        messages.append(translatedMessage)
+        
         return messages
     }
 }
+
+/*
+ if newMessage.user.id != userData.id &&
+     Language.codeToLanguage(of: newMessage.user.lang) != userData.language {
+     let translatedMessage = Message(id: newMessage.id,
+                                     of: translatedResult.translatedText,
+                                     by: sender,
+                                     language: userData.language.code,
+                                     timeStamp: timeStamp,
+                                     isTranslated: true)
+     messages.append(translatedMessage)
+ }
+*/

--- a/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
@@ -46,10 +46,10 @@ struct Message: Codable {
     }
     
     mutating func setType(by userID: Int) {
-        if isTranslated {
-            type = .translated
+        guard sender.id != userID else {
+            type = .sent
             return
         }
-        type = (sender.id == userID) ? .sent : .received
+        type = isTranslated ? .translated : .received
     }
 }


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 서버에 언어 감지 기능이 추가된 후 그에 맞는 로직으로 변경합니다.
- MessageParser의 로직을 변경합니다.
- 원래 메시지와 번역된 메시지가 언어가 같으면 하나만 보여줍니다.

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] MessageParser 로직 수정
- [x] 원래 메시지와 번역된 메시지가 언어가 같으면 하나만 보여주기

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
