### PR TITLE
[Feature/#314] User schema 변경 및 deleteUser API 수정

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   lang      String
   rooms     Room[]
   messages  Message[]
+  isDeleted Boolean   @default(false)
   createdAt DateTime  @default(now())
   updatedAt DateTime  @default(now()) @updatedAt
 }

--- a/server/src/api/models.graphql
+++ b/server/src/api/models.graphql
@@ -4,6 +4,7 @@ type User {
   avatar: String!
   password: String
   lang: String!
+  isDeleted: Boolean!
   rooms: [Room!]!
   messages: [Message]!
 }
@@ -19,11 +20,11 @@ type Room {
 }
 
 type Message {
-  id: Int!   
+  id: Int!
   text: String!
   source: String!
-  room: Room!     
-  user: User!  
+  room: Room!
+  user: User!
   createdAt: String
-  updatedAt: String   
+  updatedAt: String
 }


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- Issue #314 
- **사용자가 퇴장해도 해당 사용자의 메세지는 보존하기 위해 api를 수정합니다.**

- 기존의 deleteUser
  - user를 삭제하고 delete cascade에 따라 user가 작성한 message, user와 room 간의 관계 데이터를 제거

- 변경할 deleteUser
  - user table에 isDeleted attribute 추가 (default value: false)
  - 퇴장한 user의 isDeleted를 true로 변경
  - delete가 일어난 room의 남은 user 수를 계산해 0명일 시 room과 user 모두를 삭제

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [ ] deleteUser api가 호출될 시 해당 user의 isDeleted가 true로 설정되는가?
- [ ] 해당 room에 더 이상 user가 없다면 room과 user, _RoomToUser 내의 정보도 사라지는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
