### PR TITLE
[Feature/#316] Client의 deleteUser API 변경 대응

### DIFF
--- a/client/graphql.schema.json
+++ b/client/graphql.schema.json
@@ -16,23 +16,9 @@
         "description": "",
         "fields": [
           {
-            "name": "allMessagesById",
+            "name": "allMessagesByPage",
             "description": "",
             "args": [
-              {
-                "name": "id",
-                "description": null,
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null
-              },
               {
                 "name": "page",
                 "description": null,
@@ -52,6 +38,37 @@
               "kind": "OBJECT",
               "name": "allMessages",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "allMessagesByTime",
+            "description": "",
+            "args": [
+              {
+                "name": "time",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Message",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -114,6 +131,22 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "me",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "User",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -125,6 +158,16 @@
         "kind": "SCALAR",
         "name": "Int",
         "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "String",
+        "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
         "fields": null,
         "inputFields": null,
         "interfaces": null,
@@ -282,16 +325,6 @@
         ],
         "inputFields": null,
         "interfaces": [],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "SCALAR",
-        "name": "String",
-        "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -508,6 +541,22 @@
             "deprecationReason": null
           },
           {
+            "name": "isDeleted",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "rooms",
             "description": "",
             "args": [],
@@ -554,6 +603,16 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "SCALAR",
+        "name": "Boolean",
+        "description": "The `Boolean` scalar type represents `true` or `false`.",
+        "fields": null,
+        "inputFields": null,
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -793,16 +852,6 @@
         "possibleTypes": null
       },
       {
-        "kind": "SCALAR",
-        "name": "Boolean",
-        "description": "The `Boolean` scalar type represents `true` or `false`.",
-        "fields": null,
-        "inputFields": null,
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
         "kind": "OBJECT",
         "name": "translationResponse",
         "description": "",
@@ -1010,6 +1059,33 @@
             "deprecationReason": null
           },
           {
+            "name": "deleteUser",
+            "description": "",
+            "args": [
+              {
+                "name": "roomId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "deleteUserResponse",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "newUser",
             "description": "",
             "args": [
@@ -1032,6 +1108,49 @@
               "kind": "OBJECT",
               "name": "User",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "deleteUserResponse",
+        "description": "",
+        "fields": [
+          {
+            "name": "id",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "roomId",
+            "description": "",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/client/src/generated/types.ts
+++ b/client/src/generated/types.ts
@@ -19,15 +19,20 @@ export type Scalars = {
 
 export type Query = {
   __typename?: 'Query';
-  allMessagesById?: Maybe<AllMessages>;
+  allMessagesByPage?: Maybe<AllMessages>;
+  allMessagesByTime?: Maybe<Array<Maybe<Message>>>;
   allRooms?: Maybe<Array<Maybe<Room>>>;
   roomById?: Maybe<Room>;
   allUsers?: Maybe<Array<Maybe<User>>>;
+  me: User;
 };
 
-export type QueryAllMessagesByIdArgs = {
-  id: Scalars['Int'];
+export type QueryAllMessagesByPageArgs = {
   page: Scalars['Int'];
+};
+
+export type QueryAllMessagesByTimeArgs = {
+  time: Scalars['String'];
 };
 
 export type QueryRoomByIdArgs = {
@@ -69,6 +74,7 @@ export type User = {
   avatar: Scalars['String'];
   password?: Maybe<Scalars['String']>;
   lang: Scalars['String'];
+  isDeleted: Scalars['Boolean'];
   rooms: Array<Room>;
   messages: Array<Maybe<Message>>;
 };
@@ -127,6 +133,7 @@ export type EnterRoomResponse = {
 export type Subscription = {
   __typename?: 'Subscription';
   newMessage?: Maybe<Message>;
+  deleteUser?: Maybe<DeleteUserResponse>;
   newUser?: Maybe<User>;
 };
 
@@ -135,6 +142,16 @@ export type SubscriptionNewMessageArgs = {
   lang: Scalars['String'];
 };
 
+export type SubscriptionDeleteUserArgs = {
+  roomId: Scalars['Int'];
+};
+
 export type SubscriptionNewUserArgs = {
+  roomId: Scalars['Int'];
+};
+
+export type DeleteUserResponse = {
+  __typename?: 'deleteUserResponse';
+  id: Scalars['Int'];
   roomId: Scalars['Int'];
 };

--- a/client/src/queries/room.queires.ts
+++ b/client/src/queries/room.queires.ts
@@ -34,6 +34,7 @@ export const ROOM_BY_ID = gql`
         avatar
         nickname
         lang
+        isDeleted
       }
     }
   }

--- a/client/src/routes/Room.tsx
+++ b/client/src/routes/Room.tsx
@@ -6,6 +6,7 @@ import SideBar from '@components/Room/SideBar';
 import Input from '@components/Room/Input';
 import useMessages from '@hooks/useMessages';
 import useUsers from '@hooks/useUsers';
+import { User } from '@/generated/types';
 
 interface MatchParams {
   id: string;
@@ -38,19 +39,18 @@ const Room: FC<RouteComponentProps<MatchParams>> = ({ match }) => {
 
   if (messagesLoading || usersLoading) return <div>Loading!</div>;
 
+  const validUser = usersData.roomById.users.filter(
+    (user: User) => !user.isDeleted,
+  );
   return (
     <>
       <Header
         visible={visible}
         setVisible={setVisible}
         code={code}
-        users={usersData.roomById.users}
+        users={validUser}
       />
-      <SideBar
-        visible={visible}
-        setVisible={setVisible}
-        users={usersData.roomById.users}
-      />
+      <SideBar visible={visible} setVisible={setVisible} users={validUser} />
       <ChatLog
         messages={messagesData.allMessagesByPage.messages}
         page={page}


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- Issue #316 
- deleteUser가 변경됨에 따라 client에서 isDeleted attribute를 이용하여 해당 유저의 유효성을 검증합니다.

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [ ] 유저의 입/퇴장 정보가 실시간으로 반영되는가? (기존에 동작하던 기능에 변경은 없는가)
- [ ] refresh가 일어나도 퇴장한 유저의 메세지가 남아 있는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
