### PR TITLE
[Feature/#320] 번역된 메시지를 리턴하는 함수와 & 2nd Language를 리턴하는 함수 추가

### DIFF
--- a/server/src/utils/getSecondLang.ts
+++ b/server/src/utils/getSecondLang.ts
@@ -27,10 +27,9 @@ export default (users: User[], lang: string): string => {
       countObj[key1] > countObj[key2] ? key1 : key2,
     );
     return key;
-  } else {
-    if (lang === 'en') {
-      return 'ko';
-    }
-    return 'en';
   }
+  if (lang === 'en') {
+    return 'ko';
+  }
+  return 'en';
 };

--- a/server/src/utils/getSecondLang.ts
+++ b/server/src/utils/getSecondLang.ts
@@ -1,0 +1,36 @@
+interface User {
+  id: number;
+  avatar: string;
+  nickname: string;
+  lang: string;
+}
+
+interface CountObject {
+  [key: string]: number;
+}
+
+export default (users: User[], lang: string): string => {
+  const countObj: CountObject = {};
+
+  for (let i = 0; i < users.length; i++) {
+    const userLang = users[i].lang;
+    if (userLang !== lang) {
+      if (!countObj[userLang]) {
+        countObj[userLang] = 1;
+      } else {
+        countObj[userLang] = ++countObj[userLang];
+      }
+    }
+  }
+  if (Object.keys(countObj).length) {
+    const key = Object.keys(countObj).reduce((key1, key2) =>
+      countObj[key1] > countObj[key2] ? key1 : key2,
+    );
+    return key;
+  } else {
+    if (lang === 'en') {
+      return 'ko';
+    }
+    return 'en';
+  }
+};

--- a/server/src/utils/translateText.ts
+++ b/server/src/utils/translateText.ts
@@ -34,13 +34,12 @@ export default async (message: Message, lang: string, users: User[]): Promise<st
       };
       return JSON.stringify(texts);
     }
-  } else {
-    const secondLang = getSecondLang(users, lang);
-    const translatedText = await req(text, source, secondLang);
-    const texts = {
-      originText: text,
-      translatedText,
-    };
-    return JSON.stringify(texts);
   }
+  const secondLang = getSecondLang(users, lang);
+  const translatedText = await req(text, source, secondLang);
+  const texts = {
+    originText: text,
+    translatedText,
+  };
+  return JSON.stringify(texts);
 };

--- a/server/src/utils/translateText.ts
+++ b/server/src/utils/translateText.ts
@@ -1,0 +1,46 @@
+import getSecondLang from '@utils/getSecondLang';
+import req from './request';
+
+interface User {
+  id: number;
+  avatar: string;
+  nickname: string;
+  lang: string;
+}
+
+interface Message {
+  text: string;
+  source: string;
+  user: User;
+}
+
+export default async (message: Message, lang: string, users: User[]): Promise<string> => {
+  const authorLang = message.user.lang;
+  const { text, source } = message;
+
+  if (authorLang !== lang) {
+    if (message.source === lang) {
+      const translatedText = await req(text, source, authorLang); // 원본: 내가 사용하는 언어, 번역본: 메시지 작성자의 언어
+      const texts = {
+        originText: text,
+        translatedText,
+      };
+      return JSON.stringify(texts);
+    } else {
+      const translatedText = await req(text, source, lang); // 원본: 내가 사용하는 언어, 번역본: 메시지 작성자의 언어
+      const texts = {
+        originText: text,
+        translatedText,
+      };
+      return JSON.stringify(texts);
+    }
+  } else {
+    const secondLang = getSecondLang(users, lang);
+    const translatedText = await req(text, source, secondLang);
+    const texts = {
+      originText: text,
+      translatedText,
+    };
+    return JSON.stringify(texts);
+  }
+};


### PR DESCRIPTION
## 설명
> 이슈에 대한 설명을 작성합니다. 담당자도 함께 작성하면 좋습니다.

Issue #320
- 번역된 메시지를 리턴하는 유틸 함수 추가하기.
  - ```js
    if(채팅을 작성한 사람이 나랑 다른 국적일 때) {
        if(다른 국적이지만 내 언어를 사용할 때) {
            translatedText=작성자의 언어
        } else(다른 국적이면서 나랑 다른 언어 사용) {
            translatedText=내언어
        }
    } else(채팅을 작성한 사람이 나랑 같은 국적일 때 또는 내가 작성한 글일때) {
        translatedText=2nd 언어
    }
    ```
- 해당 채팅방의 본인 언어를 제외한 2번째로 많은 언어를 리턴하는 함수 추가하기.
  - 대화방의 모든 사람이 같은 언어코드 사용 => `en: default='ko'` , `나머지: default='en'`
  - 방의 언어코드가2종류 이상 => 2번째로 많은 언어를 리턴

## 체크사항
> 이슈를 close하기 위해 필요한 조건들을 체크박스로 나열합니다.

- [x] 번역된 메시지가 잘 리턴되는 지 확인 부탁드립니다.
- [x] 해당 채팅방의 본인의 언어를 제외한 2번째로 많은 언어가 리턴되는 지 확인 부탁드립니다.

## 참고자료
> 이슈를 해결하기 위해 필요한 참고자료가 있다면 추가합니다.

## 관련 논의
> 이슈에 대한 논의가 있었다면 논의 내용을 간략하게 추가합니다.
