### PR TITLE
[Feature/#315] iOS message timeStamp 저장 방식 수정

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
@@ -34,7 +34,8 @@ final class MessageBox {
     }
     
     func setMessageIsFirst(of newMessage: Message, comparedBy lastMessage: Message) -> Message {
-        let isNotFirstOfDay = Calendar.isSameDate(of: newMessage.timeStamp, with: lastMessage.timeStamp)
+        let isNotFirstOfDay = Calendar.isSameDate(of: newMessage.time,
+                                                  with: lastMessage.time)
         var message = newMessage
         message.setIsFirst(with: !isNotFirstOfDay)
         return message
@@ -50,7 +51,8 @@ final class MessageBox {
         guard newMessage.type == .received,
               lastMessage.type == .received,
               newMessage.sender.id == lastMessage.sender.id,
-              DateFormatter.chatTimeFormat(of: newMessage.timeStamp) == DateFormatter.chatTimeFormat(of: lastMessage.timeStamp) else {
+              DateFormatter.chatTimeFormat(of: newMessage.time) == DateFormatter.chatTimeFormat(of: lastMessage.time)
+        else {
             return newMessage
         }
         var message = newMessage
@@ -60,7 +62,7 @@ final class MessageBox {
     
     private func setShouldTimeShow(of newMessage: Message, comparedBy lastMessage: Message) {
         guard newMessage.sender.id == lastMessage.sender.id,
-              DateFormatter.chatTimeFormat(of: newMessage.timeStamp) == DateFormatter.chatTimeFormat(of: lastMessage.timeStamp) else {
+              DateFormatter.chatTimeFormat(of: newMessage.time) == DateFormatter.chatTimeFormat(of: lastMessage.time) else {
             messages.append(newMessage)
             return
         }

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/ReceivedMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/ReceivedMessageCell.swift
@@ -26,9 +26,9 @@ final class ReceivedMessageCell: UICollectionViewCell {
 
 extension ReceivedMessageCell: MessageCell {
     func configureMessageCell(message: Message) {
-        configureDate(of: dateBadge, dateBadgeHeight: dateBadgeHeight, with: message.timeStamp, isFirst: message.isFirstOfDay)
+        configureDate(of: dateBadge, dateBadgeHeight: dateBadgeHeight, with: message.time, isFirst: message.isFirstOfDay)
         configureMessage(of: messageTextView, with: message.text)
-        configureTime(of: timeLabel, with: message.timeStamp, shouldShow: message.shouldTimeShow)
+        configureTime(of: timeLabel, with: message.time, shouldShow: message.shouldTimeShow)
         configureSenderInfo(image: message.sender.image,
                             nickName: message.sender.nickName,
                             shouldImageShow: message.shouldImageShow)

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/SentMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/SentMessageCell.swift
@@ -17,8 +17,8 @@ final class SentMessageCell: UICollectionViewCell {
 
 extension SentMessageCell: MessageCell {
     func configureMessageCell(message: Message) {
-        configureDate(of: dateBadge, dateBadgeHeight: dateBadgeHeight, with: message.timeStamp, isFirst: message.isFirstOfDay)
+        configureDate(of: dateBadge, dateBadgeHeight: dateBadgeHeight, with: message.time, isFirst: message.isFirstOfDay)
         configureMessage(of: messageTextView, with: message.text)
-        configureTime(of: timeLabel, with: message.timeStamp, shouldShow: message.shouldTimeShow)
+        configureTime(of: timeLabel, with: message.time, shouldShow: message.shouldTimeShow)
     }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/TranslatedMessageCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MessageCell/TranslatedMessageCell.swift
@@ -15,6 +15,6 @@ final class TranslatedMessageCell: UICollectionViewCell {
 extension TranslatedMessageCell: MessageCell {
     func configureMessageCell(message: Message) {
         configureMessage(of: messageTextView, with: message.text)
-        configureTime(of: timeLabel, with: message.timeStamp, shouldShow: message.shouldTimeShow)
+        configureTime(of: timeLabel, with: message.time, shouldShow: message.shouldTimeShow)
     }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
@@ -12,19 +12,23 @@ struct Message: Codable {
     let text: String
     let sender: User
     let language: String
-    let timeStamp: Date
+    let timeStamp: String
     var isFirstOfDay: Bool
     var type: MessageType
     var isTranslated: Bool
     var shouldTimeShow: Bool = true
     var shouldImageShow: Bool = true
     
+    var time: Date {
+        return timeStamp.toDate()
+    }
+    
     init(of text: String, by sender: User) {
         self.id = nil
         self.text = text
         self.sender = sender
         self.language = sender.language.code
-        self.timeStamp = Date()
+        self.timeStamp = ""
         self.isFirstOfDay = true
         self.type = .sent
         isTranslated = false
@@ -35,7 +39,7 @@ struct Message: Codable {
         self.text = text
         self.sender = sender
         self.language = language
-        self.timeStamp = timeStamp.toDate()
+        self.timeStamp = timeStamp
         self.isFirstOfDay = true
         self.type = .received
         self.isTranslated = isTranslated


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- App이 Background에 가 있는 등 수신하지 못한 메시지를 가져오기 위한 allMessageByTime 쿼리를 위해 Message의 timeStamp 저장 데이터를 변경합니다. 
- (기존) Date type으로 변환 & 저장 -> (변경) 13자리 timeStamp String Type으로 저장 
- 사용할 때는 `message.time` 를 통해 사용 (연산프로퍼티에서 Date Type으로 변경 후 return)

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 기존의 time stamp 로직이 정상적으로 작동하는가

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
