### PR TITLE
[Fix/#348] : 채팅화면 음성인식 버튼 오류 수정

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Chat/View/MicrophoneButton.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/View/MicrophoneButton.swift
@@ -83,7 +83,8 @@ final class MicrophoneButton: RoundShadowButton {
     func moveToLatest() {
         isOnSpeeching = false
         UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut) { [weak self] in
-            self?.center = self?.latestCenter ?? .zero
+            guard let self = self else { return }
+            self.center = self.latestCenter ?? self.center
         }
     }
     


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 채팅방 입장 후 키보드가 관련 노티피케이션이 잘못 호출되어 버튼의 center가 zero로 이동하는 현상 발생
- 최근 좌표가 존재하지 않을경우 현재 위치에 머무르도록 수정

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 음성인식 버튼이 정상적으로 동작하는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
