### PR TITLE
[Feature/#360] iOS 새로운 채팅방 입장 전 이전 채팅방에서 나가기 기능 구현 

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/ChatCodeInput/ChatCodeInputViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/ChatCodeInput/ChatCodeInputViewReactor.swift
@@ -83,6 +83,7 @@ final class ChatCodeInputViewReactor: Reactor {
     }
     
     private func requestEnterRoom(state: State, lastInput: String) -> Observable<Mutation> {
+        networkService.leaveRoom()
         let code = state.codeInput.reduce("") { $0 + $1 } + lastInput
         return networkService.enterRoom(user: userData.user, code: code)
             .asObservable()

--- a/iOS/PapagoTalk/PapagoTalk/Coordinator/ChatCoordinator.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Coordinator/ChatCoordinator.swift
@@ -67,7 +67,7 @@ extension ChatCoordinator: ChatCoordinating {
                 let reactor = SpeechViewReactor(networkService: networkService,
                                                 userData: userData,
                                                 translationManager: translationManager,
-                                                speechManager: speechManager,
+                                                speechManager: SpeechManager(userData: userData),
                                                 roomID: roomID)
                 return SpeechViewController(coder: coder, reactor: reactor)
             }

--- a/iOS/PapagoTalk/PapagoTalk/Home/HomeViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Home/HomeViewReactor.swift
@@ -120,6 +120,7 @@ final class HomeViewReactor: Reactor {
     }
     
     private func requestCreateRoom() -> Observable<Mutation> {
+        networkService.leaveRoom()
         return networkService.createRoom(user: userData.user)
             .asObservable()
             .do(onNext: { [weak self] in 


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 비정상적인 앱 종료시 유저가 대화방에서 나가지지 않는 현상 발생
- 새로운 대화방입장시 기존의 토큰으로 대화방 나가기 요청을 보내는 형식으로 변경


## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 새로운 대화방 입장시, 기존의 대화방에서 나가기 처리 되는가

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
