### PR TITLE
[Feature/#363] iOS 파파고API 직접 번역에서 서버 중계 번역으로 변경

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Coordinator/ChatCoordinator.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Coordinator/ChatCoordinator.swift
@@ -13,7 +13,6 @@ final class ChatCoordinator: Coordinator {
     
     var networkService: NetworkServiceProviding
     var userData: UserDataProviding
-    var translationManager: PapagoAPIServiceProviding
     var speechManager: SpeechServiceProviding
     var messageParser: MessageParser
     
@@ -22,13 +21,11 @@ final class ChatCoordinator: Coordinator {
     
     init(networkService: NetworkServiceProviding,
          userData: UserDataProviding,
-         translationManager: PapagoAPIServiceProviding,
          speechManager: SpeechServiceProviding,
          messageParser: MessageParser) {
         
         self.networkService = networkService
         self.userData = userData
-        self.translationManager = translationManager
         self.speechManager = speechManager
         self.messageParser = messageParser
     }
@@ -66,7 +63,6 @@ extension ChatCoordinator: ChatCoordinating {
             creator: { [unowned self] coder -> SpeechViewController? in
                 let reactor = SpeechViewReactor(networkService: networkService,
                                                 userData: userData,
-                                                translationManager: translationManager,
                                                 speechManager: speechManager,
                                                 roomID: roomID)
                 return SpeechViewController(coder: coder, reactor: reactor)

--- a/iOS/PapagoTalk/PapagoTalk/Coordinator/MainCoordinator.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Coordinator/MainCoordinator.swift
@@ -13,7 +13,6 @@ final class MainCoordinator: Coordinator {
     var networkService: NetworkServiceProviding
     var userData: UserDataProviding
     var alertFactory: AlertFactoryProviding
-    var translationManager: PapagoAPIServiceProviding
     var speechManager: SpeechServiceProviding
     var messageParser: MessageParser
     var childCoordinator: [Coordinator] = []
@@ -22,7 +21,6 @@ final class MainCoordinator: Coordinator {
          networkService: NetworkServiceProviding,
          userData: UserDataProviding,
          alertFactory: AlertFactoryProviding,
-         translationManager: PapagoAPIServiceProviding,
          speechManager: SpeechServiceProviding,
          messageParser: MessageParser) {
         
@@ -30,7 +28,6 @@ final class MainCoordinator: Coordinator {
         self.networkService = networkService
         self.userData = userData
         self.alertFactory = alertFactory
-        self.translationManager = translationManager
         self.speechManager = speechManager
         self.messageParser = messageParser
         
@@ -46,7 +43,6 @@ final class MainCoordinator: Coordinator {
         
         let chatCoordinator = ChatCoordinator(networkService: networkService,
                                               userData: userData,
-                                              translationManager: translationManager,
                                               speechManager: speechManager,
                                               messageParser: messageParser)
         

--- a/iOS/PapagoTalk/PapagoTalk/Network/NetworkServiceProviding.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Network/NetworkServiceProviding.swift
@@ -21,9 +21,7 @@ protocol NetworkServiceProviding {
     
     func getUserList(of roomID: Int) -> Maybe<FindRoomByIdQuery.Data>
     
-    func subscribeLeavedUser(roomID: Int) -> Observable<LeavedUserSubscription.Data>
-    
-    func subscribeNewUser(roomID: Int) -> Observable<NewUserSubscription.Data>
+    func translate(text: String) -> Maybe<String>
     
     func leaveRoom()
     

--- a/iOS/PapagoTalk/PapagoTalk/SceneDelegate.swift
+++ b/iOS/PapagoTalk/PapagoTalk/SceneDelegate.swift
@@ -19,7 +19,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let networkService = ApolloNetworkService()
         let alertFactory = AlertFactory()
         let userData = UserDataProvider()
-        let translationManager = PapagoAPIManager()
         let speechManager = SpeechManager(userData: userData)
         let messageParser = MessageParser(userData: userData)
         
@@ -28,7 +27,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                                       networkService: networkService,
                                       userData: userData,
                                       alertFactory: alertFactory,
-                                      translationManager: translationManager,
                                       speechManager: speechManager,
                                       messageParser: messageParser)
         coordinator?.start()

--- a/iOS/PapagoTalk/PapagoTalk/Speech/SpeechViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Speech/SpeechViewReactor.swift
@@ -38,7 +38,6 @@ final class SpeechViewReactor: Reactor {
     }
     
     private let speechManager: SpeechServiceProviding
-    private let translationManager: PapagoAPIServiceProviding
     private let userData: UserDataProviding
     private let networkService: NetworkServiceProviding
     private let roomID: Int
@@ -47,13 +46,11 @@ final class SpeechViewReactor: Reactor {
     
     init(networkService: NetworkServiceProviding,
          userData: UserDataProviding,
-         translationManager: PapagoAPIServiceProviding,
          speechManager: SpeechServiceProviding,
          roomID: Int) {
         
         self.networkService = networkService
         self.userData = userData
-        self.translationManager = translationManager
         self.speechManager = speechManager
         self.roomID = roomID
         
@@ -115,11 +112,14 @@ final class SpeechViewReactor: Reactor {
     }
     
     private func translate(text: String) -> Observable<Mutation> {
-        let oppositeLanguage: Language = userData.language == .korean ? .english : .korean
-        return translationManager
-            .requestTranslation(request: TranslationRequest(source: userData.language.code,
-                                                            target: oppositeLanguage.code,
-                                                            text: text))
+//        let oppositeLanguage: Language = userData.language == .korean ? .english : .korean
+//        return translationManager
+//            .requestTranslation(request: TranslationRequest(source: userData.language.code,
+//                                                            target: oppositeLanguage.code,
+//                                                            text: text))
+//            .asObservable()
+//            .map { Mutation.setTranslatedText($0) }
+        return networkService.translate(text: text)
             .asObservable()
             .map { Mutation.setTranslatedText($0) }
     }

--- a/iOS/PapagoTalk/PapagoTalk/Speech/SpeechViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Speech/SpeechViewReactor.swift
@@ -112,13 +112,6 @@ final class SpeechViewReactor: Reactor {
     }
     
     private func translate(text: String) -> Observable<Mutation> {
-//        let oppositeLanguage: Language = userData.language == .korean ? .english : .korean
-//        return translationManager
-//            .requestTranslation(request: TranslationRequest(source: userData.language.code,
-//                                                            target: oppositeLanguage.code,
-//                                                            text: text))
-//            .asObservable()
-//            .map { Mutation.setTranslatedText($0) }
         return networkService.translate(text: text)
             .asObservable()
             .map { Mutation.setTranslatedText($0) }


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 기존에 파파고API로 직접 번역을 요청하는 방식에서 서버에서 구현이 완료된 Mutation을 활용하는 방식으로 변경
- TranslateMutation을 요청하는 쿼리함수 구현
- URLSession관련 함수 제거
- URLSession관련 파일은 일단은 유지

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 음성인식화면에서 실시간 번역이 정상적으로 동작하는가?
- [x] 현재 채팅방 상황에서 알맞은 언어로 번역이 동작하는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
