### PR TITLE
[Feature/#364] Subscription API에도 사용자 정보 사용을 위한 토큰 복호화 추가

### DIFF
--- a/server/src/api/Message/createSystemMessage/createSystemMessage.graphql
+++ b/server/src/api/Message/createSystemMessage/createSystemMessage.graphql
@@ -1,0 +1,3 @@
+type Mutation {
+  createSystemMessage(source: String!): Boolean
+}

--- a/server/src/api/Message/createSystemMessage/createSystemMessage.ts
+++ b/server/src/api/Message/createSystemMessage/createSystemMessage.ts
@@ -1,0 +1,43 @@
+import { PrismaClient } from '@prisma/client';
+import TRIGGER from '@utils/trigger';
+
+const prisma = new PrismaClient();
+
+export default {
+  Mutation: {
+    createSystemMessage: async (
+      _: any,
+      { source }: { source: string },
+      { request, pubsub }: any,
+    ): Promise<boolean> => {
+      const { id, nickname, avatar, lang, roomId } = request.user;
+      const newMessage = await prisma.message.create({
+        data: {
+          text: `${nickname}님이 ${source === 'in' ? '들어왔습니다' : '나갔습니다'}`,
+          source,
+          user: {
+            connect: {
+              id,
+            },
+          },
+          room: {
+            connect: {
+              id: roomId,
+            },
+          },
+        },
+        include: {
+          user: true,
+        },
+      });
+
+      pubsub.publish(TRIGGER.NEW_MESSAGE, { newMessage });
+      if (source === 'in') {
+        pubsub.publish(TRIGGER.NEW_USER, { newUser: { id, nickname, avatar, lang, roomId } });
+        return true;
+      }
+      pubsub.publish(TRIGGER.DELETE_USER, { deleteUser: { id, roomId } });
+      return true;
+    },
+  },
+};

--- a/server/src/api/Message/newMessage/newMessage.graphql
+++ b/server/src/api/Message/newMessage/newMessage.graphql
@@ -1,3 +1,3 @@
 type Subscription {
-  newMessage(roomId: Int!, lang: String!): Message
+  newMessage: Message
 }

--- a/server/src/api/Message/newMessage/newMessage.ts
+++ b/server/src/api/Message/newMessage/newMessage.ts
@@ -9,12 +9,11 @@ export default {
   Subscription: {
     newMessage: {
       subscribe: withFilter(
-        (_: any, __: any, { pubsub }: any) => pubsub.asyncIterator(TRIGGER.NEW_MESSAGE),
-        async (payload, variables): Promise<boolean> => {
-          if (payload.newMessage.roomId === variables.roomId) {
-
+        (_: any, __: any, { pubsub }: any): any => pubsub.asyncIterator(TRIGGER.NEW_MESSAGE),
+        async (payload, variables, context): Promise<boolean> => {
+          const { roomId, lang } = context.connection.context.user;
+          if (payload.newMessage.roomId === roomId) {
             const message = payload.newMessage;
-            const { roomId, lang } = variables;
 
             if (message.source === 'in' || message.source === 'out') {
               return true;

--- a/server/src/api/Room/createRoom/createRoom.ts
+++ b/server/src/api/Room/createRoom/createRoom.ts
@@ -15,7 +15,6 @@ export default {
     createRoom: async (
       _: any,
       args: User,
-      { pubsub }: any,
     ): Promise<{ userId: number; roomId: number; code: string; token: string }> => {
       const { nickname, avatar, lang } = args;
       const newUser = await prisma.user.create({
@@ -38,28 +37,6 @@ export default {
         },
       });
       const jwtToken = generateToken(newUser, newRoom.id);
-
-      const newMessage = await prisma.message.create({
-        data: {
-          text: `${nickname}님이 들어왔습니다`,
-          source: 'in',
-          user: {
-            connect: {
-              id: newUser.id,
-            },
-          },
-          room: {
-            connect: {
-              id: newRoom.id,
-            },
-          },
-        },
-        include: {
-          user: true,
-        },
-      });
-
-      pubsub.publish('NEW_MESSAGE', { newMessage });
 
       return { userId: newUser.id, roomId: newRoom.id, code: randomCode, token: jwtToken };
     },

--- a/server/src/api/Room/enterRoom/enterRoom.ts
+++ b/server/src/api/Room/enterRoom/enterRoom.ts
@@ -1,6 +1,5 @@
 import generateToken from '@utils/generateToken';
 import { PrismaClient } from '@prisma/client';
-import TRIGGER from '@utils/trigger';
 
 const prisma = new PrismaClient();
 
@@ -17,7 +16,6 @@ export default {
     enterRoom: async (
       _: any,
       { nickname, avatar, lang, code }: EnterInfo,
-      { pubsub }: any,
     ): Promise<{ userId: number; roomId: number; token: string }> => {
       const newUser = await prisma.user.create({
         data: {
@@ -31,30 +29,6 @@ export default {
         include: { rooms: true },
       });
       const jwtToken = generateToken(newUser, newUser.rooms[0].id);
-
-      const newMessage = await prisma.message.create({
-        data: {
-          text: `${nickname}님이 들어왔습니다`,
-          source: 'in',
-          user: {
-            connect: {
-              id: newUser.id,
-            },
-          },
-          room: {
-            connect: {
-              id: newUser.rooms[0].id,
-            },
-          },
-        },
-        include: {
-          user: true,
-        },
-      });
-
-      pubsub.publish(TRIGGER.NEW_MESSAGE, { newMessage });
-      pubsub.publish(TRIGGER.NEW_USER, { newUser });
-
       return { userId: newUser.id, roomId: newUser.rooms[0].id, token: jwtToken };
     },
   },

--- a/server/src/api/User/deleteUser/deleteUser.graphql
+++ b/server/src/api/User/deleteUser/deleteUser.graphql
@@ -8,5 +8,5 @@ type deleteUserResponse {
 }
 
 type Subscription {
-  deleteUser(roomId: Int!): deleteUserResponse
+  deleteUser: deleteUserResponse
 }

--- a/server/src/api/User/deleteUser/deleteUser.ts
+++ b/server/src/api/User/deleteUser/deleteUser.ts
@@ -6,34 +6,10 @@ const prisma = new PrismaClient();
 
 export default {
   Mutation: {
-    deleteUser: async (
-      _: any,
-      __: any,
-      { pubsub, request, isAuthenticated }: any,
-    ): Promise<boolean> => {
+    deleteUser: async (_: any, __: any, { request, isAuthenticated }: any): Promise<boolean> => {
       isAuthenticated(request);
 
-      const { id, nickname, roomId } = request.user;
-
-      const newMessage = await prisma.message.create({
-        data: {
-          text: `${nickname}님이 나갔습니다`,
-          source: 'out',
-          user: {
-            connect: {
-              id,
-            },
-          },
-          room: {
-            connect: {
-              id: roomId,
-            },
-          },
-        },
-        include: {
-          user: true,
-        },
-      });
+      const { id, roomId } = request.user;
 
       await prisma.user.update({
         where: {
@@ -58,11 +34,7 @@ export default {
       if (!restUser) {
         await prisma.$queryRaw`delete from user where user.id in (select B from room join _roomtouser on A = ${roomId} AND room.id = A );`;
         await prisma.$queryRaw`DELETE FROM Room WHERE id = ${roomId}`;
-        return true;
       }
-
-      pubsub.publish(TRIGGER.NEW_MESSAGE, { newMessage });
-      pubsub.publish(TRIGGER.DELETE_USER, { deleteUser: { id, roomId } });
       return true;
     },
   },
@@ -70,9 +42,10 @@ export default {
   Subscription: {
     deleteUser: {
       subscribe: withFilter(
-        (_: any, __: any, { pubsub }: any) => pubsub.asyncIterator('DELETE_USER'),
-        async (payload, variables): Promise<boolean> => {
-          if (payload.deleteUser.roomId === variables.roomId) return true;
+        (_: any, __: any, { pubsub }: any) => pubsub.asyncIterator(TRIGGER.DELETE_USER),
+        async (payload, variables, context): Promise<boolean> => {
+          const { roomId } = context.connection.context.user;
+          if (payload.deleteUser.roomId === roomId) return true;
           return false;
         },
       ),

--- a/server/src/api/User/newUser/newUser.graphql
+++ b/server/src/api/User/newUser/newUser.graphql
@@ -1,3 +1,3 @@
 type Subscription {
-  newUser(roomId: Int!): User
+  newUser: User
 }

--- a/server/src/api/User/newUser/newUser.ts
+++ b/server/src/api/User/newUser/newUser.ts
@@ -6,8 +6,9 @@ export default {
     newUser: {
       subscribe: withFilter(
         (_: any, __: any, { pubsub }: any) => pubsub.asyncIterator(TRIGGER.NEW_USER),
-        async (payload, variables): Promise<boolean> => {
-          if (payload.newUser.rooms[0].id === variables.roomId) return true;
+        async (payload, variables, context): Promise<boolean> => {
+          const { roomId } = context.connection.context.user;
+          if (payload.newUser.roomId === roomId) return true;
           return false;
         },
       ),

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,3 +1,4 @@
+import { PrismaClient } from '@prisma/client';
 import './env';
 import { GraphQLServer, PubSub } from 'graphql-yoga';
 import { authenticateJwt } from './middlewares/passport';
@@ -5,19 +6,36 @@ import isAuthenticated from './middlewares/isAuthenticated';
 import schema from './schema';
 import logger from 'morgan';
 import 'module-alias/register';
+import { verify } from 'jsonwebtoken';
 
 const PORT = process.env.PORT || 4000;
+
+const prisma = new PrismaClient();
 
 const pubsub = new PubSub();
 
 const server = new GraphQLServer({
   schema,
-  context: ({ request }) => ({ request, isAuthenticated, pubsub }),
+  context: ({ request, connection }) => ({ request, connection, isAuthenticated, pubsub }),
 });
 
 server.express.use(logger('dev'));
 server.express.use(authenticateJwt);
 
-server.start({ port: PORT, cors: { origin: '*' } }, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-});
+server.start(
+  {
+    port: PORT,
+    cors: { origin: true },
+    subscriptions: {
+      onConnect: async (connectionParams: any, webSocket: any) => {
+        const user: any = verify(connectionParams, process.env.JWT_SECRET_KEY as string);
+        const findUser = await prisma.user.findOne({ where: { id: user.id } });
+        if (!findUser) throw new Error('Not valid user token');
+        return { user: { ...findUser, roomId: user.roomId } };
+      },
+    },
+  },
+  () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  },
+);


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 웹소켓 통신에 토큰 유효화 검증을 도입하기 위해 서버 변경
  - [server] 유저가 채팅방 입퇴장시 publish(newMessage)하던 부분 분리
  - 예) createRoom 순서 : 채팅방 입장 -> 토큰 생성 -> publish(newMessage)
  - [client] 채팅방 입퇴장 이후 subscribe(newMessage)하기

- API parameter 변경
  - newMessage API가 parameter를 필요로 하지 않습니다.
  - newUserAPI가 parameter를 필요로 하지 않습니다.
  - deleteUser API가 parameter를 필요로 하지 않습니다.

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] ws protocol을 이용하는 API도 토큰이 없는 경우 동작하지 않는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
