### PR TITLE
[Feature/#356] iOS 앱 suspend 상태에서 돌아오면 못 받은 메시지 받기 기능 구현

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
+++ b/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
@@ -150,6 +150,9 @@
 		BBC5B31C257E089900739CD8 /* KeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC5B31B257E089900739CD8 /* KeychainAccess.swift */; };
 		BBC5B322257E0CFC00739CD8 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC5B321257E0CFC00739CD8 /* KeychainError.swift */; };
 		BBC5B328257E0E4500739CD8 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC5B327257E0E4500739CD8 /* Keychain.swift */; };
+		BBDE2C6B25825C720068D7DE /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDE2C6A25825C720068D7DE /* Date+.swift */; };
+		BBDE2C7725830AB90068D7DE /* Userable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDE2C7625830AB90068D7DE /* Userable.swift */; };
+		BBDE2C7D25830B3C0068D7DE /* Messageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBDE2C7C25830B3C0068D7DE /* Messageable.swift */; };
 		BBE140772573D374000B0604 /* DateFormatter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBE140762573D374000B0604 /* DateFormatter+.swift */; };
 		BBEA1A5C256F4678009B8B5F /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEA1A5B256F4678009B8B5F /* Message.swift */; };
 		BBEA1A60256F46FE009B8B5F /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBEA1A5F256F46FE009B8B5F /* User.swift */; };
@@ -164,7 +167,7 @@
 		BBF3B6F7257FB927004578D4 /* ChatRoomInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9964795225769BD500CFF202 /* ChatRoomInfo.swift */; };
 		BBF3B6FA257FB942004578D4 /* ReceivedMessageBubbleTail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482EB0257DB35200802B45 /* ReceivedMessageBubbleTail.swift */; };
 		BBF3B6FD257FB946004578D4 /* SentMessageBubbleTail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482EAC257DB34700802B45 /* SentMessageBubbleTail.swift */; };
-		BBFFC1C92581CE7200B241F0 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482FA52580F25500802B45 /* API.swift */; };
+		BBFFC1C92581CE7200B241F0 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		BBFFC1CC2581CEC100B241F0 /* UserDataProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 995BE9D425762AC500C15AC7 /* UserDataProviding.swift */; };
 		BBFFC1CF2581CFA400B241F0 /* MicButtonSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482F45257FCE1700802B45 /* MicButtonSize.swift */; };
 		BBFFC1D22581CFB600B241F0 /* SystemMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99482F992580ED6700802B45 /* SystemMessageCell.swift */; };
@@ -304,6 +307,9 @@
 		BBC5B31B257E089900739CD8 /* KeychainAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainAccess.swift; sourceTree = "<group>"; };
 		BBC5B321257E0CFC00739CD8 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
 		BBC5B327257E0E4500739CD8 /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		BBDE2C6A25825C720068D7DE /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
+		BBDE2C7625830AB90068D7DE /* Userable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Userable.swift; sourceTree = "<group>"; };
+		BBDE2C7C25830B3C0068D7DE /* Messageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Messageable.swift; sourceTree = "<group>"; };
 		BBE140762573D374000B0604 /* DateFormatter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+.swift"; sourceTree = "<group>"; };
 		BBEA1A5B256F4678009B8B5F /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		BBEA1A5F256F46FE009B8B5F /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -581,6 +587,7 @@
 				990DE9772573A67C00340A72 /* String+.swift */,
 				996A146A256D5B6200F21215 /* Locale+.swift */,
 				BB93C2932575345200C68491 /* Calendar+.swift */,
+				BBDE2C6A25825C720068D7DE /* Date+.swift */,
 				BBE140762573D374000B0604 /* DateFormatter+.swift */,
 			);
 			path = Extension;
@@ -622,9 +629,11 @@
 		BBEA1A63256F49A8009B8B5F /* Entity */ = {
 			isa = PBXGroup;
 			children = (
-				BBEA1A5B256F4678009B8B5F /* Message.swift */,
-				995BE9F62576350A00C15AC7 /* TranslatedResult.swift */,
 				BBEA1A5F256F46FE009B8B5F /* User.swift */,
+				BBDE2C7625830AB90068D7DE /* Userable.swift */,
+				BBEA1A5B256F4678009B8B5F /* Message.swift */,
+				BBDE2C7C25830B3C0068D7DE /* Messageable.swift */,
+				995BE9F62576350A00C15AC7 /* TranslatedResult.swift */,
 				9964795225769BD500CFF202 /* ChatRoomInfo.swift */,
 				BB4814C72577DCC800CFA6DB /* TranslationRequest.swift */,
 				BB4814CB2577DCE400CFA6DB /* TranslationResponse.swift */,
@@ -948,8 +957,10 @@
 				996479372576854900CFF202 /* MessageText.swift in Sources */,
 				BBC5B328257E0E4500739CD8 /* Keychain.swift in Sources */,
 				99482F46257FCE1800802B45 /* MicButtonSize.swift in Sources */,
+				BBDE2C6B25825C720068D7DE /* Date+.swift in Sources */,
 				99482F19257F826800802B45 /* SpeechServiceProviding.swift in Sources */,
 				BB5EFE9125812A90001A121C /* UserDataSource.swift in Sources */,
+				BBDE2C7D25830B3C0068D7DE /* Messageable.swift in Sources */,
 				99482FC625811E2300802B45 /* MessageSection.swift in Sources */,
 				BB93C2942575345200C68491 /* Calendar+.swift in Sources */,
 				BB48149E2577D64D00CFA6DB /* URLSessionNetworkService.swift in Sources */,
@@ -1017,6 +1028,7 @@
 				9932CF5B256CC6A4002459D0 /* HomeViewReactor.swift in Sources */,
 				990DE9782573A67C00340A72 /* String+.swift in Sources */,
 				BB6F7EC0256D697500D66F8E /* ChatViewController.swift in Sources */,
+				BBDE2C7725830AB90068D7DE /* Userable.swift in Sources */,
 				BB15A58F25776D2F0006D258 /* SpeechViewReactor.swift in Sources */,
 				BB23C09B2576979C001D74A0 /* NetworkError.swift in Sources */,
 				BB1FFD1525761BB100E4668C /* ChatDrawerState.swift in Sources */,
@@ -1036,7 +1048,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BB987E9A257F4EA700F4C258 /* User.swift in Sources */,
-				BBFFC1C92581CE7200B241F0 /* API.swift in Sources */,
+				BBFFC1C92581CE7200B241F0 /* (null) in Sources */,
 				BB987E9D257F4EAC00F4C258 /* Language.swift in Sources */,
 				BB1569A4257F8C5B00A2C0F9 /* MessageParserMock.swift in Sources */,
 				BB987EB8257F4FF200F4C258 /* RevisionedData.swift in Sources */,

--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
@@ -57,6 +57,12 @@ final class ChatViewController: UIViewController, StoryboardView {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        NotificationCenter.default.rx.notification(UIApplication.willEnterForegroundNotification)
+            .asObservable()
+            .map { _ in Reactor.Action.fetchMissingMessages }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         sendButton.rx.tap
             .withLatestFrom(inputBarTextView.rx.text)
             .compactMap { $0 }

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
@@ -41,6 +41,13 @@ final class MessageBox {
         setShouldTimeShow(of: message, comparedBy: lastMessage)
     }
     
+    func lastMessageTimeStamp() -> String {
+        guard let lastMessage = messages.last else {
+            return Date.presentTimeStamp()
+        }
+        return lastMessage.timeStamp
+    }
+    
     func setMessageIsFirst(of newMessage: Message, comparedBy lastMessage: Message) -> Message {
         let isNotFirstOfDay = Calendar.isSameDate(of: newMessage.time,
                                                   with: lastMessage.time)

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageBox.swift
@@ -21,18 +21,21 @@ final class MessageBox {
     }
     
     func append(_ message: Message) {
-        guard message.type != .system else {
+        guard let lastMessage = messages.last else {
+            var message = message
+            if message.type != .system {
+                message = setType(of: message)
+            }
             messages.append(message)
+            return
+        }
+        
+        guard lastMessage.time <= message.time else {
             return
         }
         
         var message = message
         message = setType(of: message)
-        
-        guard let lastMessage = messages.last else {
-            messages.append(message)
-            return
-        }
         message = setMessageIsFirst(of: message, comparedBy: lastMessage)
         message = setShouldImageShow(of: message, comparedBy: lastMessage)
         setShouldTimeShow(of: message, comparedBy: lastMessage)

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageParseProviding.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageParseProviding.swift
@@ -9,4 +9,5 @@ import Foundation
 
 protocol MessageParseProviding {
     func parse(newMessage: GetMessageSubscription.Data.NewMessage) -> [Message]
+    func parse(missingMessages: [GetMessageByTimeQuery.Data.AllMessagesByTime?]?) -> [Message]
 }

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
@@ -43,6 +43,9 @@ struct MessageParser: MessageParseProviding {
         //        }
         
         let translatedMessage = Message(data: newMessage, with: translatedResult, timeStamp: timeStamp, isTranslated: true)
+        guard !translatedMessage.text.isEmpty else {
+            return messages
+        }
         messages.append(translatedMessage)
         
         return messages

--- a/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/MessageParser.swift
@@ -47,4 +47,35 @@ struct MessageParser: MessageParseProviding {
         
         return messages
     }
+    
+    func parse(missingMessages: [GetMessageByTimeQuery.Data.AllMessagesByTime?]?) -> [Message] {
+        guard let messages = missingMessages, !messages.isEmpty else {
+            return []
+        }
+        var parsedMessages = [Message]()
+        
+        for message in messages {
+            guard let message = message else { return parsedMessages }
+            
+            if message.source == "in" || message.source == "out" {
+                let systemMessageText = message.source == "in" ?
+                   Strings.Chat.userJoinMessage : Strings.Chat.userLeaveMessage
+                parsedMessages.append(Message(systemText: message.user.nickname + systemMessageText,
+                                       timeStamp: message.createdAt ?? ""))
+                break
+            }
+            
+            if let timeStamp = message.createdAt,
+               let data = message.text.data(using: .utf8),
+               let translatedResult: TranslatedResult = try? data.decoded() {
+                
+                let originMessage = Message(data: message, with: translatedResult, timeStamp: timeStamp)
+                parsedMessages.append(originMessage)
+                
+                let translatedMessage = Message(data: message, with: translatedResult, timeStamp: timeStamp, isTranslated: true)
+                parsedMessages.append(translatedMessage)
+            }
+        }
+        return parsedMessages
+    }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Common/Extension/Date+.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Common/Extension/Date+.swift
@@ -1,0 +1,17 @@
+//
+//  Date+.swift
+//  PapagoTalk
+//
+//  Created by 송민관 on 2020/12/10.
+//
+
+import Foundation
+
+extension Date {
+
+    static func presentTimeStamp() -> String {
+        var timeStamp = Date().timeIntervalSince1970
+        timeStamp *= 1000
+        return String(String(timeStamp).prefix(13))
+    }
+}

--- a/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/Message.swift
@@ -34,12 +34,10 @@ struct Message: Codable {
         isTranslated = false
     }
     
-    typealias GetMessageData = GetMessageSubscription.Data.NewMessage
-    
-    init(data: GetMessageData, with text: TranslatedResult, timeStamp: String, isTranslated: Bool = false) {
+    init(data: Messageable, with text: TranslatedResult, timeStamp: String, isTranslated: Bool = false) {
         self.id = data.id
         self.text = isTranslated ? text.translatedText : text.originText
-        self.sender = User(data: data.user)
+        self.sender = User(data: data.userData)
         self.language = data.source
         self.timeStamp = timeStamp
         self.isFirstOfDay = true

--- a/iOS/PapagoTalk/PapagoTalk/Entity/Messageable.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/Messageable.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol Messageable {
     var id: Int { get set }
     var text: String { get set }
+    var userData: Userable { get }
     var source: String { get set }
 }
 
@@ -17,7 +18,13 @@ typealias GetMessageData = GetMessageSubscription.Data.NewMessage
 typealias GetMissingMessageData = GetMessageByTimeQuery.Data.AllMessagesByTime
 
 extension GetMessageData: Messageable {
+    var userData: Userable {
+        return self.user
+    }
 }
 
 extension GetMissingMessageData: Messageable {
+    var userData: Userable {
+        return self.user
+    }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Entity/Messageable.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/Messageable.swift
@@ -1,0 +1,23 @@
+//
+//  Messageable.swift
+//  PapagoTalk
+//
+//  Created by 송민관 on 2020/12/11.
+//
+
+import Foundation
+
+protocol Messageable {
+    var id: Int { get set }
+    var text: String { get set }
+    var source: String { get set }
+}
+
+typealias GetMessageData = GetMessageSubscription.Data.NewMessage
+typealias GetMissingMessageData = GetMessageByTimeQuery.Data.AllMessagesByTime
+
+extension GetMessageData: Messageable {
+}
+
+extension GetMissingMessageData: Messageable {
+}

--- a/iOS/PapagoTalk/PapagoTalk/Entity/User.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/User.swift
@@ -31,9 +31,7 @@ struct User: Codable {
         self.isMe = (id == userID) ? true : false
     }
     
-    typealias GetMessageUserData = GetMessageSubscription.Data.NewMessage.User
-    
-    init(data: GetMessageUserData) {
+    init(data: Userable) {
         self.id = data.id
         self.nickName = data.nickname
         self.image = data.avatar
@@ -41,9 +39,7 @@ struct User: Codable {
         self.isMe = false
     }
     
-    typealias GetUserListUserData = FindRoomByIdQuery.Data.RoomById.User
-    
-    init(data: GetUserListUserData, userID: Int) {
+    init(data: Userable, userID: Int) {
         self.id = data.id
         self.nickName = data.nickname
         self.image = data.avatar

--- a/iOS/PapagoTalk/PapagoTalk/Entity/Userable.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Entity/Userable.swift
@@ -1,0 +1,28 @@
+//
+//  Userable.swift
+//  PapagoTalk
+//
+//  Created by 송민관 on 2020/12/11.
+//
+
+import Foundation
+
+protocol Userable {
+    var id: Int { get set }
+    var nickname: String { get set }
+    var avatar: String { get set }
+    var lang: String { get set }
+}
+
+typealias GetMessageUserData = GetMessageSubscription.Data.NewMessage.User
+typealias GetMissingMessageUserData = GetMessageByTimeQuery.Data.AllMessagesByTime.User
+typealias GetUserListData = FindRoomByIdQuery.Data.RoomById.User
+
+extension GetMessageUserData: Userable {
+}
+
+extension GetMissingMessageUserData: Userable {
+}
+
+extension GetUserListData: Userable {
+}

--- a/iOS/PapagoTalk/PapagoTalk/Network/ApolloNetworkService.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Network/ApolloNetworkService.swift
@@ -35,7 +35,6 @@ class ApolloNetworkService: NetworkServiceProviding {
     private(set) lazy var client = ApolloClient(networkTransport: self.splitNetworkTransport, store: store)
     
     func sendMessage(text: String) -> Maybe<SendMessageMutation.Data> {
-        
         return Maybe.create { [weak self] observer in
             let cancellable = self?.client.perform(
                 mutation: SendMessageMutation(text: text),
@@ -72,6 +71,32 @@ class ApolloNetworkService: NetworkServiceProviding {
                         }
                     case .failure:
                         self?.reconnect()
+                    }
+                }
+            )
+            return Disposables.create {
+                cancellable?.cancel()
+            }
+        }
+    }
+    
+    func getMissingMessage(timeStamp: String) -> Maybe<GetMessageByTimeQuery.Data> {
+        return Maybe.create { [weak self] observer in
+            let cancellable = self?.client.fetch(
+                query: GetMessageByTimeQuery(timeStamp: timeStamp),
+                cachePolicy: .fetchIgnoringCacheCompletely,
+                resultHandler: { result in
+                    switch result {
+                    case let .success(gqlResult):
+                        if let errors = gqlResult.errors {
+                            observer(.error(errors.first!))
+                        } else if let data = gqlResult.data {
+                            observer(.success(data))
+                        } else {
+                            observer(.completed)
+                        }
+                    case let .failure(error):
+                        observer(.error(error))
                     }
                 }
             )

--- a/iOS/PapagoTalk/PapagoTalk/Network/NetworkServiceProviding.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Network/NetworkServiceProviding.swift
@@ -11,11 +11,11 @@ import RxSwift
 protocol NetworkServiceProviding {
     func sendMessage(text: String) -> Maybe<SendMessageMutation.Data>
     
-    func getMessage(roomID: Int,
-                    userID: Int) -> Observable<GetMessageSubscription.Data>
+    func getMessage(roomID: Int, userID: Int) -> Observable<GetMessageSubscription.Data>
     
-    func enterRoom(user: User,
-                   code: String) -> Maybe<JoinChatResponse>
+    func getMissingMessage(timeStamp: String) -> Maybe<GetMessageByTimeQuery.Data>
+    
+    func enterRoom(user: User, code: String) -> Maybe<JoinChatResponse>
     
     func createRoom(user: User) -> Maybe<CreateRoomResponse>
     


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.


Issue #356 
- 앱이 Suspend상태가 되었을 때, 돌아온 유저가 이전의 메시지를 받을 수 있는 기능을 구현합니다.


Issue #373 
- 번역 불가능한 메시지 함께 처리
- 서버에서 번역이 불가능한 메시지의 경우, 번역된 텍스트를 빈텍스트로 보내는 것으로 협의
- 따라서 번역된 텍스트가 빈텍스트일경우 별도의 메시지를 생성하지 않는 방식으로 구현

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 대화방에 참여하고 있다가, 앱이 Suspended 된 상태에서 다시 대화방에 들어가면, 못 받은 메시지 모두 받아와 지는가
- [x] 번역이 불가능한 메시지가 정상적으로 수신되는가?
- [x] 번역이 불가능한 메시지를 수신한 경우 추가적인 번역 메시지 셀을 생성하지 않는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
