### PR TITLE
[Feature/#413] iOS ChatHistory 날짜 표시 설정

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
+++ b/iOS/PapagoTalk/PapagoTalk.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		BB48149E2577D64D00CFA6DB /* URLSessionNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB48149D2577D64D00CFA6DB /* URLSessionNetworkService.swift */; };
 		BB4814A22577D79B00CFA6DB /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4814A12577D79B00CFA6DB /* HTTPMethod.swift */; };
 		BB4814CC2577DCE400CFA6DB /* TranslationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB4814CB2577DCE400CFA6DB /* TranslationResponse.swift */; };
+		BB4985802587438100896432 /* TimeFormatType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB49857F2587438100896432 /* TimeFormatType.swift */; };
 		BB52F51B2570977300B7577B /* UICollectionReusableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB52F51A2570977300B7577B /* UICollectionReusableView+.swift */; };
 		BB5EFE7C25812991001A121C /* UserSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5EFE7B25812991001A121C /* UserSection.swift */; };
 		BB5EFE9125812A90001A121C /* UserDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB5EFE9025812A90001A121C /* UserDataSource.swift */; };
@@ -317,6 +318,7 @@
 		BB4814A12577D79B00CFA6DB /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
 		BB4814C72577DCC800CFA6DB /* TranslationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationRequest.swift; sourceTree = "<group>"; };
 		BB4814CB2577DCE400CFA6DB /* TranslationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslationResponse.swift; sourceTree = "<group>"; };
+		BB49857F2587438100896432 /* TimeFormatType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeFormatType.swift; sourceTree = "<group>"; };
 		BB52F51A2570977300B7577B /* UICollectionReusableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionReusableView+.swift"; sourceTree = "<group>"; };
 		BB5EFE7B25812991001A121C /* UserSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserSection.swift; sourceTree = "<group>"; };
 		BB5EFE9025812A90001A121C /* UserDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDataSource.swift; sourceTree = "<group>"; };
@@ -511,6 +513,7 @@
 				BB20F4DE2573959500C5AC1D /* UserDefaultType.swift */,
 				BB1FFD1425761BB100E4668C /* ChatDrawerState.swift */,
 				99482F45257FCE1700802B45 /* MicButtonSize.swift */,
+				BB49857F2587438100896432 /* TimeFormatType.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -1088,6 +1091,7 @@
 				99482E5F257BA37F00802B45 /* HomeCoordinating.swift in Sources */,
 				9968474325847B73006C116E /* ChatCollectionView.swift in Sources */,
 				996A1446256D187900F21215 /* ImageFactoryProviding.swift in Sources */,
+				BB4985802587438100896432 /* TimeFormatType.swift in Sources */,
 				990DE9292572665400340A72 /* ChatCodeInputViewReactor.swift in Sources */,
 				995BE9AB2575E8E500C15AC7 /* MainCoordinator.swift in Sources */,
 				993AF67D2574E3E200416692 /* HomeError.swift in Sources */,
@@ -1109,9 +1113,8 @@
 				9932CF5B256CC6A4002459D0 /* HomeViewReactor.swift in Sources */,
 				990DE9782573A67C00340A72 /* String+.swift in Sources */,
 				BB6F7EC0256D697500D66F8E /* ChatViewController.swift in Sources */,
-				BBDE2C7725830AB90068D7DE /* Userable.swift in Sources */,
-				9968476425851988006C116E /* HistoryModel.xcdatamodeld in Sources */,
 				BBDE2C7725830AB90068D7DE /* UserData.swift in Sources */,
+				9968476425851988006C116E /* HistoryModel.xcdatamodeld in Sources */,
 				BB15A58F25776D2F0006D258 /* SpeechViewReactor.swift in Sources */,
 				BB23C09B2576979C001D74A0 /* NetworkError.swift in Sources */,
 				BB1FFD1525761BB100E4668C /* ChatDrawerState.swift in Sources */,

--- a/iOS/PapagoTalk/PapagoTalk/Common/Enum/TimeFormatType.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Common/Enum/TimeFormatType.swift
@@ -1,0 +1,28 @@
+//
+//  TimeFormatType.swift
+//  PapagoTalk
+//
+//  Created by 송민관 on 2020/12/14.
+//
+
+import Foundation
+
+enum TimeFormatType {
+    case time
+    case yesterday
+    case date
+    case fullDate
+    
+    var format: String {
+        switch self {
+        case .time:
+            return "a h:mm"
+        case .yesterday:
+            return "yesterday".localized
+        case .date:
+            return "MMMM dd".localized
+        case .fullDate:
+            return "M. d. yyyy.".localized
+        }
+    }
+}

--- a/iOS/PapagoTalk/PapagoTalk/Common/Extension/Calendar+.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Common/Extension/Calendar+.swift
@@ -14,4 +14,16 @@ extension Calendar {
     static func isSameDate(of firstDate: Date, with secondDate: Date) -> Bool {
         return calendar.isDate(firstDate, inSameDayAs: secondDate)
     }
+    
+    static func isToday(of date: Date) -> Bool {
+        return calendar.isDateInToday(date)
+    }
+    
+    static func isYesterday(of date: Date) -> Bool {
+        return calendar.isDateInYesterday(date)
+    }
+    
+    static func isSameYear(of date: Date) -> Bool {
+        return calendar.isDate(Date(), equalTo: date, toGranularity: self.Component.year)
+    }
 }

--- a/iOS/PapagoTalk/PapagoTalk/Common/Extension/DateFormatter+.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Common/Extension/DateFormatter+.swift
@@ -22,4 +22,10 @@ extension DateFormatter {
         dateFormatter.locale = Locale(identifier: Locale.autoupdatingCurrent.identifier)
         return dateFormatter.string(from: date)
     }
+    
+    static func chatHistoryTimeFormat(of date: Date, type: TimeFormatType) -> String {
+        dateFormatter.dateFormat = type.format
+        dateFormatter.locale = Locale(identifier: Locale.autoupdatingCurrent.identifier)
+        return dateFormatter.string(from: date)
+    }
 }

--- a/iOS/PapagoTalk/PapagoTalk/History/HistoryCell.swift
+++ b/iOS/PapagoTalk/PapagoTalk/History/HistoryCell.swift
@@ -23,7 +23,7 @@ class HistoryCell: UITableViewCell {
         titleLabel.text = history.title
         nicknameLabel.text = history.usedNickname
         languageLabel.text = history.usedLanguage.localizedText
-        dateLabel.text = DateFormatter.chatDateFormat(of: history.enterDate)
+        configureDateLabel(by: history.enterDate)
     }
     
     private func configureImage(with imageURL: String) {
@@ -31,6 +31,22 @@ class HistoryCell: UITableViewCell {
             return
         }
         profileImageView.kf.setImage(with: imageURL)
+    }
+    
+    private func configureDateLabel(by date: Date) {
+        var type: TimeFormatType
+        
+        switch date {
+        case date where Calendar.isToday(of: date):
+            type = .time
+        case date where Calendar.isYesterday(of: date):
+            type = .yesterday
+        case date where Calendar.isSameYear(of: date):
+            type = .date
+        default:
+            type = .fullDate
+        }
+        dateLabel.text = DateFormatter.chatHistoryTimeFormat(of: date, type: type)
     }
     
     @IBAction func reEnterButtonTapped(_ sender: UIButton) {

--- a/iOS/PapagoTalk/PapagoTalk/en.lproj/Localizable.strings
+++ b/iOS/PapagoTalk/PapagoTalk/en.lproj/Localizable.strings
@@ -30,6 +30,11 @@
 //MARK: - DateFormatter
 "yyyy MMMM dd EEEE" = "yyyy MMMM dd EEEE";
 
+//MARK: - TimeFormatType
+"yesterday" = "yesterday";
+"MMMM dd" = "MMMM dd";
+"M. d. yyyy." = "M. d. yyyy.";
+
 //MARK: - MicButtonSize
 "Big" = "Big";
 "Medium" = "Medium";

--- a/iOS/PapagoTalk/PapagoTalk/ko.lproj/Localizable.strings
+++ b/iOS/PapagoTalk/PapagoTalk/ko.lproj/Localizable.strings
@@ -30,6 +30,11 @@
 //MARK: - DateFormatter
 "yyyy MMMM dd EEEE" = "yyyy년 M월 d일 EEEE";
 
+//MARK: - TimeFormatType
+"yesterday" = "어제";
+"MMMM dd" = "M월 d일";
+"M. d. yyyy." = "yyyy. M. d.";
+
 //MARK: - MicButtonSize
 "Big" = "크게";
 "Medium" = "중간";


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 채팅방 히스토리의 날짜 표시 로직을 구성합니다.
   - 오늘인 경우 : 시간만 표시
   - 어제인 경우 : `어제` (`yesterday`) 만 표시
   - 어제는 아니지만 같은 연도인 경우 : `Month Day`만 표시
   - 다른 연도인 경우 : `Year. Month. Day` 표시

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 날짜에 알맞게 Date가 잘 표시 되는가

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
