### PR TITLE
[Bug/#411] 채팅방 재입장 시 채팅 리스트가 안뜨는 문제 수정

### DIFF
--- a/client/src/apollo/Client.ts
+++ b/client/src/apollo/Client.ts
@@ -2,6 +2,7 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { ApolloClient, HttpLink, split, InMemoryCache } from '@apollo/client';
 import { WebSocketLink } from '@apollo/client/link/ws';
 import { setContext } from '@apollo/client/link/context';
+import { SubscriptionClient } from 'subscriptions-transport-ws';
 
 const httpsUri = process.env.HTTPS_URI || 'http://localhost:4000/graphql';
 const wssUri = process.env.WSS_URI || 'ws://localhost:4000/graphql';
@@ -10,14 +11,13 @@ const httpLink = new HttpLink({
   uri: httpsUri,
 });
 
-const wsLink = new WebSocketLink({
-  uri: wssUri,
-  options: {
-    reconnect: true,
-    lazy: true,
-    connectionParams: () => ({ authToken: localStorage.getItem('token') }),
-  },
+export const wsClient = new SubscriptionClient(wssUri, {
+  reconnect: true,
+  lazy: true,
+  connectionParams: () => ({ authToken: localStorage.getItem('token') }),
 });
+
+const wsLink = new WebSocketLink(wsClient);
 
 const link = split(
   ({ query }) => {

--- a/client/src/components/Room/Header/index.tsx
+++ b/client/src/components/Room/Header/index.tsx
@@ -6,7 +6,7 @@ import { AvatarStack, Avatar } from '@primer/components';
 import { useMutation } from '@apollo/client';
 import { DELETE_USER } from '@queries/user.queries';
 import { User } from '@generated/types';
-import client from '@/apollo/Client';
+import client, { wsClient } from '@/apollo/Client';
 import { CREATE_SYSTEM_MESSAGE } from '@/queries/messege.queries';
 import S from './style';
 
@@ -31,6 +31,7 @@ const Header: React.FC<Props> = ({ visible, setVisible, code, users }) => {
     await deleteUser();
     localStorage.removeItem('token');
     client.resetStore();
+    wsClient.close();
   };
 
   const toast = () => {


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 새로고침을 하지 않고 채팅방에 재입장했을때 subscription cache가 남아있어 새로운 메세지 발행이 제대로 되지 않는 문제 수정
  - Client.ts에 SubscriptionClient 추가하고 유저 채팅방 나갈때 웹소켓 커넥션 끊기

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [ ] 채팅방에 입장한 경우 자신이 쓴 메세지, 상대방이 쓴 메세지들이 실시간으로 출력되는지 확인해주세요 :)

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

- [참고자료1](https://github.com/apollographql/subscriptions-transport-ws/issues/171)
- [참고자료2](http://www.smartjava.org/content/standalone-apollo-client/)

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
