### PR TITLE
[Fix/#446] iOS ChatDrawer tapGesture 버그 수정

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/ChatViewController.swift
@@ -77,11 +77,13 @@ final class ChatViewController: UIViewController, StoryboardView {
             .disposed(by: disposeBag)
         
         chatDrawerButton.rx.tap
+            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
             .map { Reactor.Action.chatDrawerButtonTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
         chatDrawerObserver.filter { $0 }
+            .throttle(.seconds(1), latest: false, scheduler: MainScheduler.instance)
             .map { _ in Reactor.Action.chatDrawerButtonTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)

--- a/iOS/PapagoTalk/PapagoTalk/ChatDrawer/ChatDrawerViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/ChatDrawer/ChatDrawerViewController.swift
@@ -129,7 +129,8 @@ final class ChatDrawerViewController: UIViewController, StoryboardView {
         
         visualEffectView.rx.tapGesture()
             .when(.recognized)
-            .subscribe(onNext: { [weak self] _ in
+            .first()
+            .subscribe({ [weak self] _ in
                 self?.chatDrawerObserver.accept(true)
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

ChatDrawer 상위의 VisualEffectView의 tapGesture를 ChatDrawer가 닫히고 있는 애니메이션 중에 계속 수행하면, 계속해서 ChatDrawer가 생성되는 문제 해결

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] tapGesture를 계속하여 수행해도 하나의 event만 전달되는가
- [x] tapGesture를 계속하여 수행해도 ChatDrawer가 계속 호출되는 문제가 호출 되었는가

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
