### PR TITLE
[Feature/#460] iOS 홈화면 대화방 중복 입장 방지

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Home/HomeViewController.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Home/HomeViewController.swift
@@ -80,6 +80,7 @@ final class HomeViewController: UIViewController, StoryboardView {
             .disposed(by: disposeBag)
         
         makeChatRoomButton.rx.tap
+            .throttle(.milliseconds(500), latest: false, scheduler: MainScheduler.instance)
             .map { Reactor.Action.makeChatRoomButtonTapped }
             .bind(to: reactor.action)
             .disposed(by: disposeBag)


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- 대화방 입장 버튼 연속 클릭시 대화방에 중복 입장되는 현상 해결
- 대화방 중복입장 방지를 위한 버튼이벤트 throttle 적용

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 대화방 입장 버튼을 연속해서 눌러도 한번만 입장되는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
