### PR TITLE
[Fix/#458] iOS 퇴장 시스템 메시지 중복 생성 제거

### DIFF
--- a/iOS/PapagoTalk/PapagoTalk/Chat/Model/MessageParser.swift
+++ b/iOS/PapagoTalk/PapagoTalk/Chat/Model/MessageParser.swift
@@ -13,11 +13,9 @@ struct MessageParser: MessageParseProviding {
     
     func parse(newMessage: GetMessageSubscription.Data.NewMessage) -> [Message] {
         
-        guard newMessage.source != "in",
-              newMessage.source != "out" else {
+        guard newMessage.source != "in", newMessage.source != "out" else {
             let systemMessageText = newMessage.source == "in" ?
                 Strings.Chat.userJoinMessage : Strings.Chat.userLeaveMessage
-
             return [Message(systemText: newMessage.user.nickname + systemMessageText,
                             timeStamp: newMessage.createdAt ?? "")]
         }

--- a/iOS/PapagoTalk/PapagoTalk/ChatDrawer/ChatDrawerViewReactor.swift
+++ b/iOS/PapagoTalk/PapagoTalk/ChatDrawer/ChatDrawerViewReactor.swift
@@ -33,8 +33,8 @@ final class ChatDrawerViewReactor: Reactor {
     }
     
     private let networkService: NetworkServiceProviding
-    private let userData: UserDataProviding
     private let roomID: Int
+    private var userData: UserDataProviding
     let initialState: State
     
     init(networkService: NetworkServiceProviding, userData: UserDataProviding, roomID: Int, roomCode: String) {
@@ -58,6 +58,7 @@ final class ChatDrawerViewReactor: Reactor {
             ])
         case .leaveChatRoomButtonTapped:
             networkService.leaveRoom()
+            userData.removeToken()
             return .just(Mutation.setLeaveChatRoom(true))
         }
     }

--- a/iOS/PapagoTalk/PapagoTalk/DataLayer/UserDataProvider.swift
+++ b/iOS/PapagoTalk/PapagoTalk/DataLayer/UserDataProvider.swift
@@ -12,4 +12,8 @@ struct UserDataProvider: UserDataProviding {
     @UserDefault(type: .micButtonSize, default: .small) var micButtonSize: MicButtonSize
     @UserDefault(type: .sameLanguageTranslation, default: true) var sameLanguageTranslation: Bool
     @Keychain(key: "jwt", defaultValue: "") var token: String
+    
+    func removeToken() {
+        try? KeychainAccess.shared.removeAll()
+    }
 }

--- a/iOS/PapagoTalk/PapagoTalk/DataLayer/UserDataProviding.swift
+++ b/iOS/PapagoTalk/PapagoTalk/DataLayer/UserDataProviding.swift
@@ -16,6 +16,8 @@ protocol UserDataProviding {
     var micButtonSize: MicButtonSize { get set }
     var sameLanguageTranslation: Bool { get set }
     var token: String { get set }
+    
+    func removeToken()
 }
 
 extension UserDataProviding {


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- ChatView 시스템 메시지 중 퇴장 메시지 중복 생성 제거

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] ChatView에서 퇴장 시스템 메시지가 1번만 보여지는가

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
