### PR TITLE
[Featrue/#457] 번역 API 메세지 localization

### DIFF
--- a/client/src/components/Room/Input/index.tsx
+++ b/client/src/components/Room/Input/index.tsx
@@ -19,8 +19,8 @@ const Input: React.FC = () => {
   const [text, setText] = useState('');
   const location = useLocation<LocationState>();
   const { lang } = location.state;
-  const { enterText, translationText } = getText(lang);
-  const [translatedText, setTranslatedText] = useState(enterText);
+  const { enterText, translationText, translationErrorText } = getText(lang);
+  const [translatedText, setTranslatedText] = useState(translationText);
   const [isListening, setIsListening] = useState(false);
   const { transcript } = useSpeechRecognition();
 
@@ -38,7 +38,15 @@ const Input: React.FC = () => {
 
   const getTranslatedText = debounce(async () => {
     const { data } = await translationMutation();
-    setTranslatedText(data ? data.translation.translatedText : '...');
+    console.log('data :>> ', data);
+    if (data.translation.translatedText === null)
+      setTranslatedText(translationText);
+    else
+      setTranslatedText(
+        data.translation.translatedText.length > 0
+          ? data.translation.translatedText
+          : translationErrorText,
+      );
   }, 500);
 
   const onKeyUp = () => {
@@ -59,7 +67,7 @@ const Input: React.FC = () => {
 
       await createMessageMutation();
       setText('');
-      setTranslatedText(enterText);
+      setTranslatedText(translationText);
     }
   };
 

--- a/client/src/components/Room/Input/index.tsx
+++ b/client/src/components/Room/Input/index.tsx
@@ -38,7 +38,6 @@ const Input: React.FC = () => {
 
   const getTranslatedText = debounce(async () => {
     const { data } = await translationMutation();
-    console.log('data :>> ', data);
     if (data.translation.translatedText === null)
       setTranslatedText(translationText);
     else

--- a/client/src/constants/localization.ts
+++ b/client/src/constants/localization.ts
@@ -26,7 +26,7 @@ const textList: TextObj = {
     submitCode: '입장',
     userList: '대화 상대',
     enterText: '채팅을 입력해주세요',
-    translationText: '번역',
+    translationText: '번역할 메시지를 입력해주세요',
   },
   en: {
     inputNickName: 'Enter Nickname',
@@ -38,7 +38,7 @@ const textList: TextObj = {
     submitCode: 'Enter',
     userList: 'User List',
     enterText: 'Please enter a chat',
-    translationText: 'Translation',
+    translationText: 'Please enter a message to translate',
   },
   ja: {
     inputNickName: 'ニックネーム 入力',
@@ -50,7 +50,7 @@ const textList: TextObj = {
     submitCode: '参加',
     userList: 'メンバー',
     enterText: 'チャットを入力してください',
-    translationText: '翻訳',
+    translationText: '翻訳メッセージを入力してください',
   },
   'zh-CN': {
     inputNickName: '输入昵称',
@@ -62,7 +62,7 @@ const textList: TextObj = {
     submitCode: '参与度',
     userList: '参加者名单',
     enterText: '请输入您的聊天内容',
-    translationText: '翻译',
+    translationText: '请输入要翻译的信息',
   },
 };
 

--- a/client/src/constants/localization.ts
+++ b/client/src/constants/localization.ts
@@ -9,6 +9,7 @@ interface TextList {
   userList: string;
   enterText: string;
   translationText: string;
+  translationErrorText: string;
 }
 
 interface TextObj {
@@ -18,51 +19,55 @@ interface TextObj {
 const textList: TextObj = {
   ko: {
     inputNickName: '닉네임 입력',
-    nicknameError: '닉네임은 1~12자 사이여야 합니다.',
+    nicknameError: '닉네임은 1~12자 사이여야 합니다',
     selectLanguage: '언어 선택',
     enterRoom: '대화 참여하기',
     createRoom: '방 만들기',
-    enterCode: '참여 코드(6자리의 숫자)를 입력해주세요.',
+    enterCode: '참여 코드(6자리의 숫자)를 입력해주세요',
     submitCode: '입장',
     userList: '대화 상대',
     enterText: '채팅을 입력해주세요',
-    translationText: '번역할 메시지를 입력해주세요',
+    translationText: '번역된 메세지가 출력됩니다',
+    translationErrorText: '번역에 실패했습니다',
   },
   en: {
     inputNickName: 'Enter Nickname',
-    nicknameError: 'Nickname must be between 1 and 10 characters.',
+    nicknameError: 'Nickname must be between 1 and 10 characters',
     selectLanguage: 'Select Language',
     enterRoom: 'Enter ChatRoom',
     createRoom: 'Create ChatRoom',
-    enterCode: 'Please enter 6 digits of the participating code.',
+    enterCode: 'Please enter 6 digits of the participating code',
     submitCode: 'Enter',
     userList: 'User List',
     enterText: 'Please enter a chat',
-    translationText: 'Please enter a message to translate',
+    translationText: 'The translated message is printed',
+    translationErrorText: 'Translation failed',
   },
   ja: {
     inputNickName: 'ニックネーム 入力',
-    nicknameError: 'ニックネームは1~12字の間でなければなりません。',
+    nicknameError: 'ニックネームは1~12字の間でなければなりません',
     selectLanguage: '言語選択',
     enterRoom: '会話に参加する',
     createRoom: 'トークルーム作成',
-    enterCode: '参加コード(6桁数字)を入力してください。',
+    enterCode: '参加コード(6桁数字)を入力してください',
     submitCode: '参加',
     userList: 'メンバー',
     enterText: 'チャットを入力してください',
-    translationText: '翻訳メッセージを入力してください',
+    translationText: '翻訳メッセージが出力されます',
+    translationErrorText: '翻訳に失敗しました',
   },
   'zh-CN': {
     inputNickName: '输入昵称',
-    nicknameError: '昵称必须介于1到12个字符之间。',
+    nicknameError: '昵称必须介于1到12个字符之间',
     selectLanguage: '语言选择',
     enterRoom: '加入聊天室',
     createRoom: '创建聊天室',
-    enterCode: '请输入参加代码（6位数字）。',
+    enterCode: '请输入参加代码（6位数字）',
     submitCode: '参与度',
     userList: '参加者名单',
     enterText: '请输入您的聊天内容',
-    translationText: '请输入要翻译的信息',
+    translationText: '会打印翻译好的信息',
+    translationErrorText: '翻译失败了',
   },
 };
 

--- a/client/src/queries/messege.queries.ts
+++ b/client/src/queries/messege.queries.ts
@@ -11,6 +11,7 @@ export const TRANSLATION = gql`
   mutation translation($text: String!) {
     translation(text: $text) {
       translatedText
+      errorMsg
     }
   }
 `;

--- a/client/src/utils/formatTimezone.ts
+++ b/client/src/utils/formatTimezone.ts
@@ -23,7 +23,9 @@ const formatTime = (timestamp: string, langCode: string): string => {
   const minute = now.getMinutes();
 
   const amPMTime =
-    Hour > 12 ? `오후 ${Hour - 12}:${minute}` : `오전 ${Hour}:${minute}`;
+    Hour > 12
+      ? `오후 ${Hour - 12}:${minute >= 10 ? minute : `0${minute}`}`
+      : `오전 ${Hour}:${minute >= 10 ? minute : `0${minute}`}`;
 
   return amPMTime;
 };

--- a/server/src/api/Translation/translation.graphql
+++ b/server/src/api/Translation/translation.graphql
@@ -1,5 +1,6 @@
 type translationResponse {
-  translatedText: String!
+  translatedText: String
+  errorMsg: String
 }
 
 type Mutation {

--- a/server/src/api/Translation/translation.ts
+++ b/server/src/api/Translation/translation.ts
@@ -50,7 +50,7 @@ export default {
           return { translatedText: translatedText };
         }
       } catch (e) {
-        return { translatedText: '텍스트를 입력하세요' };
+        return { translatedText: '' };
       }
     },
   },

--- a/server/src/api/Translation/translation.ts
+++ b/server/src/api/Translation/translation.ts
@@ -10,7 +10,8 @@ interface TranslationForm {
 }
 
 interface translationResponse {
-  translatedText: string;
+  translatedText?: string;
+  errorMsg?: string;
 }
 
 const prisma = new PrismaClient();
@@ -43,14 +44,11 @@ export default {
           const translatedText = await req(text, source, target);
           return { translatedText: translatedText };
         }
+
         const translatedText = await req(text, source, lang);
-        if (translatedText) {
-          return { translatedText: translatedText };
-        } else {
-          return { translatedText: translatedText };
-        }
+        return { translatedText: translatedText };
       } catch (e) {
-        return { translatedText: '' };
+        return { errorMsg: e.response.data.errorMessage };
       }
     },
   },


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- server
  - 번역 API에 에러 메세지 추가
    - translatedText return값에 null 허용
    - errorMsg return값 추가(null 허용)
- client
  - 번역창 메세지 localization
    - 번역 실패 메세지 추가
    - 번역 초기, 번역 실패한 경우, 번역 api 에러난 경우 메세지 처리
- etc
  - minute 시간 포맷팅

Issue #457

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [ ] 번역창 초기값에 `번역된 메세지가 출력됩니다` 메세지가 출력되는지 확인해주세요 :)
- [ ] 번역에 실패했을때 `번역에 실패했습니다` 메세지가 출력되는지 확인해주세요 :)

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
