### PR TITLE
[Bug/#505] 뒤로 가기 버튼 누를 때 이전 유저의 정보가 남아 있는 문제

### DIFF
--- a/client/src/routes/Home.tsx
+++ b/client/src/routes/Home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useHistory } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
@@ -13,6 +13,7 @@ import { CREATE_SYSTEM_MESSAGE } from '@queries/messege.queries';
 import { useUserState } from '@contexts/UserContext';
 import { useLocalizationState } from '@contexts/LocalizationContext';
 import encrypt from '@utils/encryption';
+import client, { wsClient } from '@/apollo/Client';
 
 const Wrapper = styled.div`
   min-width: inherit;
@@ -76,6 +77,15 @@ const Home: React.FC = () => {
       },
     });
   };
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) {
+      localStorage.removeItem('token');
+      client.resetStore();
+      wsClient.close();
+    }
+  }, []);
 
   return (
     <Wrapper>


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

Issue #505
- 채팅방에서 뒤로가기를 눌렀을 때 토큰이 사라지도록 수정
- 채팅방에서 뒤로가기를 눌렀을 때 유저 정보를 삭제하도록 수정

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 방에 입장 후 뒤로가기를 눌렀을 때 토큰을 제거하고 유저 정보를 초기화 되었는 지 확인 부탁드립니다.

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
