### PR TITLE
[Feature/#526] 채팅 입력에 debounce가 적용되지 않는 오류 수정

### DIFF
--- a/client/src/components/RoomInput/index.tsx
+++ b/client/src/components/RoomInput/index.tsx
@@ -158,6 +158,10 @@ interface LocationState {
   lang: string;
 }
 
+const debounceEvent = debounce((debounceFunction) => {
+  debounceFunction();
+}, 500);
+
 const RoomInput: React.FC = () => {
   const [text, setText] = useState('');
   const history = useHistory();
@@ -185,7 +189,7 @@ const RoomInput: React.FC = () => {
     },
   });
 
-  const getTranslatedText = debounce(async () => {
+  const getTranslatedText = async () => {
     const { data } = await translationMutation();
     if (data.translation.translatedText === null)
       setTranslatedText(translationText);
@@ -195,12 +199,12 @@ const RoomInput: React.FC = () => {
           ? data.translation.translatedText
           : translationErrorText,
       );
-  }, 500);
+  };
 
   const onKeyUp = () => {
     const checkText = text.replace(/\s/gi, '');
     if (checkText.length === 0) return;
-    getTranslatedText();
+    debounceEvent(getTranslatedText);
   };
 
   const onChangeText = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 설명

> PR에 대한 간략한 설명을 작성합니다.
> (필수) 코드를 작성한 이유를 추가한다.

- Issue #526
- 사용자의 채팅 입력 시 번역 메세지를 받아오는 통신에서 디바운스가
적용되지 않던 오류 해결

## 체크리스트

> PR 작성자와 확인하는 리뷰어님이 확인해야 할 체크리스트를 작성합니다.

- [x] 개발자 도구의 network tab을 통해 사용자 입력이 0.5초간 없을 시 **단 한 번만** API 요청이 일어나는가?

## 참고자료

> 해당 PR과 관련된 참고자료가 있을 경우 첨부합니다.

## 기타

> 리뷰어님에게 상세한 설명이 필요할 경우 추가 자료를 첨부합니다. (ex. 스크린샷)
